### PR TITLE
Fix output formatting for free

### DIFF
--- a/src/uu/free/src/free.rs
+++ b/src/uu/free/src/free.rs
@@ -82,9 +82,9 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
             let used = mem_info.total - mem_info.free;
 
             if wide {
-                println!("              total        used        free      shared     buffers       cache   available");
+                println!("               total        used        free      shared     buffers       cache   available");
                 println!(
-                    "Mem:   {:12} {:12} {:12} {:12} {:12} {:12} {:12}",
+                    "Mem:     {:11} {:11} {:11} {:11} {:11} {:11} {:11}",
                     mem_info.total,
                     used,
                     mem_info.free,
@@ -94,9 +94,9 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                     mem_info.available
                 );
             } else {
-                println!("              total        used        free      shared  buff/cache   available");
+                println!("               total        used        free      shared  buff/cache   available");
                 println!(
-                    "Mem:   {:12} {:12} {:12} {:12} {:12} {:12}",
+                    "Mem:     {:11} {:11} {:11} {:11} {:11} {:11}",
                     mem_info.total,
                     used,
                     mem_info.free,
@@ -106,7 +106,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                 );
             }
             println!(
-                "Swap:  {:12} {:12} {:12}",
+                "Swap:    {:11} {:11} {:11}",
                 mem_info.swap_total, mem_info.swap_used, mem_info.swap_free
             );
         }

--- a/tests/by-util/test_free.rs
+++ b/tests/by-util/test_free.rs
@@ -4,8 +4,8 @@
 // file that was distributed with this source code.
 // spell-checker:ignore (words) symdir somefakedir
 
-use pretty_assertions::assert_eq;
 use crate::common::util::TestScenario;
+use pretty_assertions::assert_eq;
 
 #[test]
 fn test_invalid_arg() {
@@ -27,10 +27,14 @@ fn test_free_wide() {
 
 #[test]
 fn test_free_column_format() {
-    let free_header = "               total        used        free      shared  buff/cache   available";
+    let free_header =
+        "               total        used        free      shared  buff/cache   available";
     let free_result = new_ucmd!().succeeds();
     assert_eq!(free_result.stdout_str().len(), 207);
-    assert_eq!(free_result.stdout_str().split("\n").next().unwrap(), free_header)
+    assert_eq!(
+        free_result.stdout_str().split("\n").next().unwrap(),
+        free_header
+    )
 }
 
 #[test]
@@ -38,5 +42,8 @@ fn test_free_wide_column_format() {
     let free_header = "               total        used        free      shared     buffers       cache   available";
     let free_result = new_ucmd!().arg("--wide").succeeds();
     assert_eq!(free_result.stdout_str().len(), 231);
-    assert_eq!(free_result.stdout_str().split("\n").next().unwrap(), free_header)
+    assert_eq!(
+        free_result.stdout_str().split("\n").next().unwrap(),
+        free_header
+    )
 }

--- a/tests/by-util/test_free.rs
+++ b/tests/by-util/test_free.rs
@@ -4,6 +4,7 @@
 // file that was distributed with this source code.
 // spell-checker:ignore (words) symdir somefakedir
 
+use pretty_assertions::assert_eq;
 use crate::common::util::TestScenario;
 
 #[test]
@@ -22,4 +23,20 @@ fn test_free_wide() {
     let result = new_ucmd!().arg("--wide").succeeds();
     assert!(result.stdout_str().contains("Mem:"));
     assert!(!result.stdout_str().contains("buff/cache"));
+}
+
+#[test]
+fn test_free_column_format() {
+    let free_header = "               total        used        free      shared  buff/cache   available";
+    let free_result = new_ucmd!().succeeds();
+    assert_eq!(free_result.stdout_str().len(), 207);
+    assert_eq!(free_result.stdout_str().split("\n").next().unwrap(), free_header)
+}
+
+#[test]
+fn test_free_wide_column_format() {
+    let free_header = "               total        used        free      shared     buffers       cache   available";
+    let free_result = new_ucmd!().arg("--wide").succeeds();
+    assert_eq!(free_result.stdout_str().len(), 231);
+    assert_eq!(free_result.stdout_str().split("\n").next().unwrap(), free_header)
 }


### PR DESCRIPTION
The GNU free is using 11 chars wide for number, not 12. This was also causing a misalignment of the numbers with the title.

The source for the 11 chars wide: https://gitlab.com/procps-ng/procps/-/blob/master/src/free.c?ref_type=heads#L336