### PR TITLE
w: Format time and get cmdline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,9 +124,7 @@ checksum = "8a0d04d43504c61aa6c7531f1871dd0d418d91130162063b789da00fd7057a5e"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
- "js-sys",
  "num-traits",
- "wasm-bindgen",
  "windows-targets 0.52.0",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -410,6 +410,7 @@ dependencies = [
  "sysinfo",
  "tempfile",
  "textwrap",
+ "time",
  "uu_free",
  "uu_pmap",
  "uu_pwdx",
@@ -763,6 +764,7 @@ name = "uu_w"
 version = "0.0.1"
 dependencies = [
  "clap",
+ "time",
  "uucore",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -60,6 +75,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "autocfg"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -72,16 +93,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
 
 [[package]]
+name = "bumpalo"
+version = "3.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ff69b9dd49fd426c69a0db9fc04dd934cdb6645ff000864d98f7e2af8830eaa"
+
+[[package]]
 name = "bytesize"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e368af43e418a04d52505cf3dbc23dda4e3407ae2fa99fd0e4f308ce546acc"
 
 [[package]]
+name = "cc"
+version = "1.0.90"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a0d04d43504c61aa6c7531f1871dd0d418d91130162063b789da00fd7057a5e"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-targets 0.52.0",
+]
 
 [[package]]
 name = "clap"
@@ -240,6 +287,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d3d0e0f38255e7fa3cf31335b3a56f05febd18025f4db5ef7a0cfb4f8da651f"
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "io-lifetimes"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -255,6 +325,15 @@ name = "itoa"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+
+[[package]]
+name = "js-sys"
+version = "0.3.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
+dependencies = [
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "libc"
@@ -273,6 +352,12 @@ name = "linux-raw-sys"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
+
+[[package]]
+name = "log"
+version = "0.4.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "memchr"
@@ -298,6 +383,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -397,6 +491,7 @@ dependencies = [
 name = "procps"
 version = "0.0.1"
 dependencies = [
+ "chrono",
  "clap",
  "clap_complete",
  "clap_mangen",
@@ -410,7 +505,6 @@ dependencies = [
  "sysinfo",
  "tempfile",
  "textwrap",
- "time",
  "uu_free",
  "uu_pmap",
  "uu_pwdx",
@@ -763,8 +857,8 @@ dependencies = [
 name = "uu_w"
 version = "0.0.1"
 dependencies = [
+ "chrono",
  "clap",
- "time",
  "uucore",
 ]
 
@@ -816,6 +910,60 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
 name = "wild"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ xattr = "1.3.1"
 tempfile = "3.9.0"
 rand = { version = "0.8", features = ["small_rng"] }
 bytesize = "1.3.0"
+time = { version = "0.3", features = ["formatting"] }
 
 [workspace.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
 utmpx = "0.1"
@@ -75,6 +76,7 @@ tempfile = { workspace = true }
 libc = { workspace = true }
 rand = { workspace = true }
 uucore = { workspace = true, features = ["entries", "process", "signals"] }
+time = { workspace = true, features = ["formatting"] }
 
 [target.'cfg(unix)'.dev-dependencies]
 xattr = { workspace = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ xattr = "1.3.1"
 tempfile = "3.9.0"
 rand = { version = "0.8", features = ["small_rng"] }
 bytesize = "1.3.0"
-time = { version = "0.3", features = ["formatting"] }
+chrono = { version = "0.4.37"}
 
 [workspace.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
 utmpx = "0.1"
@@ -76,7 +76,7 @@ tempfile = { workspace = true }
 libc = { workspace = true }
 rand = { workspace = true }
 uucore = { workspace = true, features = ["entries", "process", "signals"] }
-time = { workspace = true, features = ["formatting"] }
+chrono = { workspace = true }
 
 [target.'cfg(unix)'.dev-dependencies]
 xattr = { workspace = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,9 @@ xattr = "1.3.1"
 tempfile = "3.9.0"
 rand = { version = "0.8", features = ["small_rng"] }
 bytesize = "1.3.0"
-chrono = { version = "0.4.37"}
+chrono = { version = "0.4.37", default-features = false, features = [
+  "clock",
+] }
 
 [workspace.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
 utmpx = "0.1"

--- a/src/uu/w/Cargo.toml
+++ b/src/uu/w/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["command-line-utilities"]
 [dependencies]
 uucore = { workspace = true, features = ["utmpx"] }
 clap = { workspace = true }
-time = { workspace = true, features = ["formatting"] }
+chrono = { workspace = true }
 
 ['cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
 utmpx = { workspace = true }

--- a/src/uu/w/Cargo.toml
+++ b/src/uu/w/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["command-line-utilities"]
 [dependencies]
 uucore = { workspace = true, features = ["utmpx"] }
 clap = { workspace = true }
+time = { workspace = true, features = ["formatting"] }
 
 ['cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
 utmpx = { workspace = true }

--- a/src/uu/w/Cargo.toml
+++ b/src/uu/w/Cargo.toml
@@ -14,7 +14,9 @@ categories = ["command-line-utilities"]
 [dependencies]
 uucore = { workspace = true, features = ["utmpx"] }
 clap = { workspace = true }
-chrono = { workspace = true }
+chrono = { workspace = true, default-features = false, features = [
+  "clock",
+] }
 
 ['cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
 utmpx = { workspace = true }

--- a/src/uu/w/src/w.rs
+++ b/src/uu/w/src/w.rs
@@ -142,3 +142,27 @@ pub fn uu_app() -> Command {
                 .action(ArgAction::SetTrue),
         )
 }
+
+#[cfg(test)]
+mod tests {
+    use time::OffsetDateTime;
+    use crate::format_time;
+    use crate::fetch_cmdline;
+    use std::{fs::read_to_string, path::Path, process};
+
+
+    #[test]
+    fn test_format_time() {
+        let unix_epoc = OffsetDateTime::UNIX_EPOCH;
+        assert_eq!(format_time(unix_epoc).unwrap(), "00:00");
+    }
+
+    #[test]
+    // Get PID of current process and use that for cmdline testing
+    fn test_fetch_cmdline() {
+        // uucore's utmpx returns an i32, so we cast to that to mimic it.
+        let pid = process::id() as i32;
+        let path = Path::new("/proc").join(pid.to_string()).join("cmdline");
+        assert_eq!(read_to_string(path).unwrap(), fetch_cmdline(pid).unwrap())
+    }
+}

--- a/src/uu/w/src/w.rs
+++ b/src/uu/w/src/w.rs
@@ -23,12 +23,12 @@ struct UserInfo {
     command: String,
 }
 
-fn format_time(time: time::OffsetDateTime) -> Result<String, time::error::Format> {
+pub fn format_time(time: time::OffsetDateTime) -> Result<String, time::error::Format> {
     let time_format = time::format_description::parse("[hour]:[minute]").unwrap();
     time.format(&time_format)
 }
 
-fn fetch_cmdline(pid: i32) -> Result<String, std::io::Error> {
+pub fn fetch_cmdline(pid: i32) -> Result<String, std::io::Error> {
     let cmdline_path = Path::new("/proc").join(pid.to_string()).join("cmdline");
     fs::read_to_string(cmdline_path)
 }
@@ -141,28 +141,4 @@ pub fn uu_app() -> Command {
                 .help("show the PID(s) of processes in WHAT")
                 .action(ArgAction::SetTrue),
         )
-}
-
-#[cfg(test)]
-mod tests {
-    use time::OffsetDateTime;
-    use crate::format_time;
-    use crate::fetch_cmdline;
-    use std::{fs::read_to_string, path::Path, process};
-
-
-    #[test]
-    fn test_format_time() {
-        let unix_epoc = OffsetDateTime::UNIX_EPOCH;
-        assert_eq!(format_time(unix_epoc).unwrap(), "00:00");
-    }
-
-    #[test]
-    // Get PID of current process and use that for cmdline testing
-    fn test_fetch_cmdline() {
-        // uucore's utmpx returns an i32, so we cast to that to mimic it.
-        let pid = process::id() as i32;
-        let path = Path::new("/proc").join(pid.to_string()).join("cmdline");
-        assert_eq!(read_to_string(path).unwrap(), fetch_cmdline(pid).unwrap())
-    }
 }

--- a/src/uu/w/src/w.rs
+++ b/src/uu/w/src/w.rs
@@ -23,12 +23,12 @@ struct UserInfo {
     command: String,
 }
 
-pub fn format_time(time: time::OffsetDateTime) -> Result<String, time::error::Format> {
+fn format_time(time: time::OffsetDateTime) -> Result<String, time::error::Format> {
     let time_format = time::format_description::parse("[hour]:[minute]").unwrap();
     time.format(&time_format)
 }
 
-pub fn fetch_cmdline(pid: i32) -> Result<String, std::io::Error> {
+fn fetch_cmdline(pid: i32) -> Result<String, std::io::Error> {
     let cmdline_path = Path::new("/proc").join(pid.to_string()).join("cmdline");
     fs::read_to_string(cmdline_path)
 }
@@ -141,4 +141,29 @@ pub fn uu_app() -> Command {
                 .help("show the PID(s) of processes in WHAT")
                 .action(ArgAction::SetTrue),
         )
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{fetch_cmdline, format_time};
+    use std::{fs, path::Path, process};
+    use time::OffsetDateTime;
+
+    #[test]
+    fn test_format_time() {
+        let unix_epoc = OffsetDateTime::UNIX_EPOCH;
+        assert_eq!(format_time(unix_epoc).unwrap(), "00:00");
+    }
+
+    #[test]
+    // Get PID of current process and use that for cmdline testing
+    fn test_fetch_cmdline() {
+        // uucore's utmpx returns an i32, so we cast to that to mimic it.
+        let pid = process::id() as i32;
+        let path = Path::new("/proc").join(pid.to_string()).join("cmdline");
+        assert_eq!(
+            fs::read_to_string(path).unwrap(),
+            fetch_cmdline(pid).unwrap()
+        )
+    }
 }

--- a/tests/by-util/test_w.rs
+++ b/tests/by-util/test_w.rs
@@ -5,7 +5,6 @@
 // spell-checker:ignore (words) symdir somefakedir
 
 use crate::common::util::TestScenario;
-use std::path::Path;
 
 #[test]
 fn test_invalid_arg() {
@@ -26,19 +25,18 @@ fn test_output_format() {
     // Use no header to simplify testing
     let cmd = new_ucmd!().arg("--no-header").succeeds();
     let output_lines = cmd.stdout_str().lines();
-    // There is no guarantee that there will be a cmdline entry, but for testing purposes, we will assume so,
-    // since there will be one present in most cases.
+
     for line in output_lines {
-        // We need to get rid of extra 0 terminators on strings, such as the cmdline, so we don't have characters at the end.
-        let line_vec: Vec<String> = line
-            .split_whitespace()
-            .map(|s| String::from(s.trim_end_matches('\0')))
-            .collect();
+        let line_vec: Vec<String> = line.split_whitespace().map(|s| String::from(s)).collect();
         // Check the time formatting, this should be the third entry in list
-        // For now, we are just going to check that that length of time is 5 and it has a colon
-        assert!(line_vec[2].contains(":") && line_vec[2].chars().count() == 5);
-        // Check to make sure that cmdline is a path that exists.
-        // For now, cmdline will be in index 3, until the output is complete.
-        assert!(Path::new(line_vec.last().unwrap().as_str()).exists())
+        // For now, we are just going to check that that length of time is 5 and it has a colon, else
+        // it is possible that a time can look like Fri13, so it can start with a letter and end
+        // with a number
+        assert!(
+            (line_vec[2].contains(":") && line_vec[2].chars().count() == 5)
+                || (line_vec[2].starts_with(char::is_alphabetic)
+                    && line_vec[2].ends_with(char::is_numeric)
+                    && line_vec[2].chars().count() == 5)
+        );
     }
 }

--- a/tests/by-util/test_w.rs
+++ b/tests/by-util/test_w.rs
@@ -4,6 +4,8 @@
 // file that was distributed with this source code.
 // spell-checker:ignore (words) symdir somefakedir
 
+use std::{fs, path::Path, process};
+
 use crate::common::util::TestScenario;
 
 #[test]
@@ -18,4 +20,19 @@ fn test_no_header() {
     let result = cmd.stdout_str();
 
     assert!(!result.contains("USER\tTTY\t\tLOGIN@\t\tIDLE\tJCPU\tPCPU\tWHAT"));
+}
+
+#[test]
+fn test_format_time() {
+    let unix_epoc = time::OffsetDateTime::UNIX_EPOCH;
+    assert_eq!(w::format_time(unix_epoc).unwrap(), "00:00");
+}
+
+#[test]
+// Get PID of current process and use that for cmdline testing
+fn test_fetch_cmdline() {
+    // uucore's utmpx returns an i32, so we cast to that to mimic it.
+    let pid = process::id() as i32;
+    let path = Path::new("/proc").join(pid.to_string()).join("cmdline");
+    assert_eq!(fs::read_to_string(path).unwrap(), w::fetch_cmdline(pid).unwrap())
 }


### PR DESCRIPTION
This change allows w to display time in a similar way to the original procps w. Additionally, w now fetches the cmdline for each entry.

Later, the fetch_cmdline and possibly format_time functions could be seperated out into a shared library for future applications, such as `ps` or `top`.
