### PR TITLE
ci: fix "Basic CI / cargo check (windows-latest)"

### DIFF
--- a/src/uu/free/src/free.rs
+++ b/src/uu/free/src/free.rs
@@ -33,6 +33,7 @@ const ABOUT: &str = help_about!("free.md");
 const USAGE: &str = help_usage!("free.md");
 
 /// The unit of number is [UnitMultiplier::Bytes]
+#[derive(Default)]
 struct MemInfo {
     total: u64,
     free: u64,
@@ -49,18 +50,7 @@ struct MemInfo {
 #[cfg(target_os = "linux")]
 fn parse_meminfo() -> Result<MemInfo, Error> {
     let contents = fs::read_to_string("/proc/meminfo")?;
-    let mut mem_info = MemInfo {
-        total: 0,
-        free: 0,
-        available: 0,
-        shared: 0,
-        buffers: 0,
-        cached: 0,
-        swap_total: 0,
-        swap_free: 0,
-        swap_used: 0,
-        reclaimable: 0,
-    };
+    let mut mem_info = MemInfo::default();
 
     for line in contents.lines() {
         if let Some((key, value)) = line.split_once(':') {
@@ -105,6 +95,12 @@ fn parse_meminfo() -> Result<MemInfo, Box<dyn std::error::Error>> {
     };
 
     Ok(mem_info)
+}
+
+// TODO: implement function
+#[cfg(target_os = "windows")]
+fn parse_meminfo() -> Result<MemInfo, Box<dyn std::error::Error>> {
+    Ok(MemInfo::default())
 }
 
 #[uucore::main]

--- a/src/uu/w/src/w.rs
+++ b/src/uu/w/src/w.rs
@@ -6,6 +6,7 @@
 use clap::crate_version;
 use clap::{Arg, ArgAction, Command};
 use std::process;
+#[cfg(not(windows))]
 use uucore::utmpx::Utmpx;
 use uucore::{error::UResult, format_usage, help_about, help_usage};
 
@@ -22,6 +23,7 @@ struct UserInfo {
     command: String,
 }
 
+#[cfg(not(windows))]
 fn fetch_user_info() -> Result<Vec<UserInfo>, std::io::Error> {
     let mut user_info_list = Vec::new();
     for entry in Utmpx::iter_all_records() {
@@ -41,6 +43,12 @@ fn fetch_user_info() -> Result<Vec<UserInfo>, std::io::Error> {
 
     Ok(user_info_list)
 }
+
+#[cfg(windows)]
+fn fetch_user_info() -> Result<Vec<UserInfo>, std::io::Error> {
+    Ok(Vec::new())
+}
+
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let matches = uu_app().try_get_matches_from(args)?;


### PR DESCRIPTION
This PR fixes two issues that break the "Basic CI / cargo check (windows-latest)" check:

- an "unresolved import `uucore::utmpx`" error in `w`
- a "cannot find function `parse_meminfo` in this scope" error in `free`