### PR TITLE
Cargo.toml: remove utmpx

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,9 +49,6 @@ tempfile = "3.9.0"
 rand = { version = "0.8", features = ["small_rng"] }
 bytesize = "1.3.0"
 
-[workspace.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
-utmpx = "0.1"
-
 [dependencies]
 clap = { workspace = true }
 clap_complete = { workspace = true }

--- a/src/uu/w/Cargo.toml
+++ b/src/uu/w/Cargo.toml
@@ -15,9 +15,6 @@ categories = ["command-line-utilities"]
 uucore = { workspace = true, features = ["utmpx"] }
 clap = { workspace = true }
 
-['cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
-utmpx = { workspace = true }
-
 [lib]
 path = "src/w.rs"
 


### PR DESCRIPTION
This PR fixes two "unused manifest key" warnings from Cargo related to `utmpx` entries, see, for example, https://github.com/uutils/procps/actions/runs/8498779411/job/23278880657?pr=37#step:4:8.