### PR TITLE
free: prevent subtract with overflow on macOS

### DIFF
--- a/src/uu/free/src/free.rs
+++ b/src/uu/free/src/free.rs
@@ -85,10 +85,10 @@ fn parse_meminfo() -> Result<MemInfo, Box<dyn std::error::Error>> {
         available: sys.free_memory(),
         shared: 0,
         buffers: 0,
-        cached: sys.used_memory() - sys.free_memory(),
+        cached: sys.used_memory().saturating_sub(sys.free_memory()),
         swap_total: sys.total_swap(),
         swap_free: sys.free_swap(),
-        swap_used: sys.total_swap() - sys.free_swap(),
+        swap_used: sys.total_swap().saturating_sub(sys.free_swap()),
         reclaimable: 0,
     };
 


### PR DESCRIPTION
This PR should fix the "attempt to subtract with overflow" errors that make some tests fail on macOS. See, for example, https://github.com/uutils/procps/actions/runs/8505959792/job/23295337750?pr=37