### PR TITLE
watch: implement interval

### DIFF
--- a/src/uu/watch/src/watch.rs
+++ b/src/uu/watch/src/watch.rs
@@ -239,5 +239,3 @@ pub fn uu_app() -> Command {
                 .help("Pass command to exec instead of 'sh -c'"),
         )
 }
-
-

--- a/src/uu/watch/src/watch.rs
+++ b/src/uu/watch/src/watch.rs
@@ -90,6 +90,61 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     Ok(())
 }
 
+#[cfg(test)]
+mod parse_interval_tests {
+    use super::*;
+
+    #[test]
+    fn test_comma_parse() {
+        let interval = parse_interval("1,5");
+        assert_eq!(Ok(Duration::from_millis(1500)), interval);
+    }
+
+    #[test]
+    fn test_different_nanos_length() {
+        let interval = parse_interval("1.12345");
+        assert_eq!(Ok(Duration::new(1, 123450000)), interval);
+        let interval = parse_interval("1.1234");
+        assert_eq!(Ok(Duration::new(1, 123400000)), interval);
+    }
+
+    #[test]
+    fn test_period_parse() {
+        let interval = parse_interval("1.5");
+        assert_eq!(Ok(Duration::from_millis(1500)), interval);
+    }
+
+    #[test]
+    fn test_empty_seconds_interval() {
+        let interval = parse_interval(".5");
+        assert_eq!(Ok(Duration::from_millis(500)), interval);
+    }
+
+    #[test]
+    fn test_seconds_only() {
+        let interval = parse_interval("7");
+        assert_eq!(Ok(Duration::from_secs(7)), interval);
+    }
+
+    #[test]
+    fn test_empty_nanoseconds_interval() {
+        let interval = parse_interval("1.");
+        assert_eq!(Ok(Duration::from_millis(1000)), interval);
+    }
+
+    #[test]
+    fn test_too_many_nanos() {
+        let interval = parse_interval("1.00000000009");
+        assert_eq!(Ok(Duration::from_secs(1)), interval);
+    }
+
+    #[test]
+    fn test_invalid_nano() {
+        let interval = parse_interval("1.00000000000a");
+        assert!(interval.is_err())
+    }
+}
+
 pub fn uu_app() -> Command {
     Command::new(uucore::util_name())
         .version(crate_version!())
@@ -184,3 +239,5 @@ pub fn uu_app() -> Command {
                 .help("Pass command to exec instead of 'sh -c'"),
         )
 }
+
+

--- a/src/uu/watch/src/watch.rs
+++ b/src/uu/watch/src/watch.rs
@@ -3,14 +3,14 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
-use std::io::{Error, ErrorKind};
 use clap::crate_version;
 use clap::{Arg, Command};
+use std::io::{Error, ErrorKind};
+use std::num::ParseIntError;
 use std::process::{Command as SystemCommand, Stdio};
 use std::thread::sleep;
 use std::time::Duration;
 use uucore::{error::UResult, format_usage, help_about, help_usage};
-use std::num::{ParseIntError};
 
 const ABOUT: &str = help_about!("watch.md");
 const USAGE: &str = help_usage!("watch.md");
@@ -26,7 +26,11 @@ fn parse_interval(input: &str) -> Result<Duration, ParseIntError> {
     };
 
     // If the seconds string is empty, set seconds to 0
-    let seconds: u64 = if index > 0 { input[..index].parse()? } else { 0 };
+    let seconds: u64 = if index > 0 {
+        input[..index].parse()?
+    } else {
+        0
+    };
 
     let nanos_string = &input[index + 1..];
     let nanos: u32 = match nanos_string.len() {
@@ -68,7 +72,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                     format!("watch: failed to parse argument: '{input}': Invalid argument"),
                 )));
             }
-        }
+        },
     };
 
     loop {

--- a/tests/by-util/test_watch.rs
+++ b/tests/by-util/test_watch.rs
@@ -19,9 +19,7 @@ fn test_invalid_interval() {
 
 #[test]
 fn test_no_interval() {
-    let mut p = new_ucmd!()
-        .arg("true")
-        .run_no_wait();
+    let mut p = new_ucmd!().arg("true").run_no_wait();
     p.make_assertion_with_delay(500).is_alive();
     p.kill()
         .make_assertion()
@@ -33,9 +31,7 @@ fn test_no_interval() {
 #[test]
 fn test_valid_interval() {
     let args = vec!["-n", "1.5", "true"];
-    let mut p = new_ucmd!()
-        .args(&args)
-        .run_no_wait();
+    let mut p = new_ucmd!().args(&args).run_no_wait();
     p.make_assertion_with_delay(500).is_alive();
     p.kill()
         .make_assertion()
@@ -47,9 +43,7 @@ fn test_valid_interval() {
 #[test]
 fn test_valid_interval_comma() {
     let args = vec!["-n", "1,5", "true"];
-    let mut p = new_ucmd!()
-        .args(&args)
-        .run_no_wait();
+    let mut p = new_ucmd!().args(&args).run_no_wait();
     p.make_assertion_with_delay(1000).is_alive();
     p.kill()
         .make_assertion()

--- a/tests/by-util/test_watch.rs
+++ b/tests/by-util/test_watch.rs
@@ -14,7 +14,10 @@ fn test_invalid_arg() {
 #[test]
 fn test_invalid_interval() {
     let args = vec!["-n", "definitely-not-valid", "true"];
-    new_ucmd!().args(&args).fails();
+    new_ucmd!()
+        .args(&args)
+        .fails()
+        .stderr_contains("Invalid argument");
 }
 
 #[test]

--- a/tests/by-util/test_watch.rs
+++ b/tests/by-util/test_watch.rs
@@ -10,3 +10,50 @@ use crate::common::util::TestScenario;
 fn test_invalid_arg() {
     new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
 }
+
+#[test]
+fn test_invalid_interval() {
+    let args = vec!["-n", "definitely-not-valid", "true"];
+    new_ucmd!().args(&args).fails();
+}
+
+#[test]
+fn test_no_interval() {
+    let mut p = new_ucmd!()
+        .arg("true")
+        .run_no_wait();
+    p.make_assertion_with_delay(500).is_alive();
+    p.kill()
+        .make_assertion()
+        .with_all_output()
+        .no_stderr()
+        .no_stdout();
+}
+
+#[test]
+fn test_valid_interval() {
+    let args = vec!["-n", "1.5", "true"];
+    let mut p = new_ucmd!()
+        .args(&args)
+        .run_no_wait();
+    p.make_assertion_with_delay(500).is_alive();
+    p.kill()
+        .make_assertion()
+        .with_all_output()
+        .no_stderr()
+        .no_stdout();
+}
+
+#[test]
+fn test_valid_interval_comma() {
+    let args = vec!["-n", "1,5", "true"];
+    let mut p = new_ucmd!()
+        .args(&args)
+        .run_no_wait();
+    p.make_assertion_with_delay(1000).is_alive();
+    p.kill()
+        .make_assertion()
+        .with_all_output()
+        .no_stderr()
+        .no_stdout();
+}


### PR DESCRIPTION
This merge aims to add an interval parsing implementation for watch.
```
      -n, --interval seconds
              Specify update interval.  The command will not allow quicker than 0.1 second inter-
              val,  in  which the smaller values are converted. Both '.' and ',' work for any lo-
              cales. The WATCH_INTERVAL environment can be used to persistently set a non-default
              interval (following the same rules and formatting).
```

In watch.rs, a new function named `parse_interval` is added, which takes in a `&str` and returns a result with `Duration` or an error with `ParseIntError`.

The function will first see if the string contains either a '.' or a ',' character. If it does not, it attempts to parse it into seconds and return a duration with that many seconds.
Otherwise, it will attempt to split the string into the seconds and the remainder.
The remainder is then parsed and zero padded. This way we ensure 0.5 becomes 500000000 nanoseconds, and not 5.
If the string has a missing component (such as `.5` or `5.`) the function will assume 0.
Nanosecond strings that except 9 characters will first be checked if they are valid, then trimmed.
Finally, return the calculated duration or 100 milliseconds. Whichever is longer. This ensures the minimum interval of 0.1 seconds. 

Other thoughts:
1. Currently, I have used `"a".parse::<u8>()?` to get rust to return a `ParseIntError`. This is obviously not ideal, but it seems ParseIntError is private to rust, and we'd need to make a custom return type instead. This is possible, but it seemed overkill for this scenario.
2. There may be a more efficient calculation for padding the nanoseconds. I used 10u32.pow() but maybe a while loops would be more efficient.
3. The `WATCH_INTERVAL` environment variable has not been implemented yet.