### PR TITLE
w: Implement PCPU and JCPU

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -862,6 +862,7 @@ version = "0.0.1"
 dependencies = [
  "chrono",
  "clap",
+ "libc",
  "uucore",
 ]
 

--- a/src/uu/w/Cargo.toml
+++ b/src/uu/w/Cargo.toml
@@ -17,6 +17,7 @@ clap = { workspace = true }
 chrono = { workspace = true, default-features = false, features = [
   "clock",
 ] }
+libc = { workspace = true }
 
 [lib]
 path = "src/w.rs"

--- a/src/uu/w/src/w.rs
+++ b/src/uu/w/src/w.rs
@@ -3,16 +3,16 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
-#[cfg(not(windows))]
+#[cfg(target_os = "linux")]
 use chrono::{self, Datelike};
 use clap::crate_version;
 use clap::{Arg, ArgAction, Command};
-#[cfg(not(windows))]
+#[cfg(target_os = "linux")]
 use libc::{sysconf, _SC_CLK_TCK};
 use std::process;
-#[cfg(not(windows))]
+#[cfg(target_os = "linux")]
 use std::{collections::HashMap, fs, path::Path};
-#[cfg(not(windows))]
+#[cfg(target_os = "linux")]
 use uucore::utmpx::Utmpx;
 use uucore::{error::UResult, format_usage, help_about, help_usage};
 

--- a/src/uu/w/src/w.rs
+++ b/src/uu/w/src/w.rs
@@ -31,6 +31,7 @@ struct UserInfo {
 
 #[cfg(target_os = "linux")]
 fn fetch_terminal_jcpu() -> Result<HashMap<u64, f64>, std::io::Error> {
+    // Iterate over all pid folders in /proc and build a HashMap with their terminals and cpu usage.
     let pid_dirs = fs::read_dir("/proc")?
         .filter_map(Result::ok)
         .filter(|entry| entry.path().is_dir())
@@ -40,11 +41,15 @@ fn fetch_terminal_jcpu() -> Result<HashMap<u64, f64>, std::io::Error> {
                 .file_name()
                 .and_then(|s| s.to_os_string().into_string().ok())
         })
+        // Check to see if directory is an integer (pid)
         .filter_map(|pid_dir_str| pid_dir_str.parse::<i32>().ok());
     let mut pid_hashmap = HashMap::new();
     for pid in pid_dirs {
+        // Fetch terminal number for current pid
         let terminal_number = fetch_terminal_number(pid)?;
+        // Get current total CPU time for current pid
         let pcpu_time = fetch_pcpu_time(pid)?;
+        // Update HashMap with found terminal number and add pcpu time for current pid
         *pid_hashmap.entry(terminal_number).or_insert(0.0) += pcpu_time;
     }
     Ok(pid_hashmap)

--- a/tests/by-util/test_w.rs
+++ b/tests/by-util/test_w.rs
@@ -38,5 +38,8 @@ fn test_output_format() {
                     && line_vec[2].ends_with(char::is_numeric)
                     && line_vec[2].chars().count() == 5)
         );
+        // Assert that there is something in the JCPU and PCPU slots,
+        // this will need to be changed when IDLE is implemented
+        assert!(!line_vec[3].is_empty() && !line_vec[4].is_empty())
     }
 }

--- a/tests/by-util/test_w.rs
+++ b/tests/by-util/test_w.rs
@@ -21,6 +21,8 @@ fn test_no_header() {
 }
 
 #[test]
+// As of now, output is only implemented for Linux
+#[cfg(target_os = "linux")]
 fn test_output_format() {
     // Use no header to simplify testing
     let cmd = new_ucmd!().arg("--no-header").succeeds();


### PR DESCRIPTION
The w manpage defines JCPU as the total CPU time of all processes under a given tty. The PCPU is defined as being the total time being used by the command in the "what" field.

For the JCPU implementation, the program creates a hashmap of all terminal numbers and their total time by walking the pid folders in /proc. I don't think this is terrible performance-wise, as execution time is still slightly faster than the original w, when built in release mode.

Total time for a process is calculated by taking the sum of time scheduled in both user mode and kernel mode and dividing that by the system's clock tick.

In terms of tests, I've added a couple of unit tests and updated the test_output_format to make sure the JCPU and PCPU fields are populated, these still need to be formatted, so the tests don't check for formatting. 