### PR TITLE
`w`: implement --short option

### DIFF
--- a/src/uu/w/src/w.rs
+++ b/src/uu/w/src/w.rs
@@ -149,23 +149,38 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let matches = uu_app().try_get_matches_from(args)?;
 
     let no_header = matches.get_flag("no-header");
+    let short = matches.get_flag("short");
 
     match fetch_user_info() {
         Ok(user_info) => {
             if !no_header {
-                println!("USER\tTTY\tLOGIN@\tIDLE\tJCPU\tPCPU\tWHAT");
+                if !short {
+                    println!("USER\tTTY\tLOGIN@\tIDLE\tJCPU\tPCPU\tWHAT");
+                } else {
+                    println!("USER\tTTY\tIDLE\tWHAT");
+                }
             }
             for user in user_info {
-                println!(
-                    "{}\t{}\t{}\t{}\t{}s\t{}s\t{}",
-                    user.user,
-                    user.terminal,
-                    user.login_time,
-                    user.idle_time,
-                    user.jcpu,
-                    user.pcpu,
-                    user.command
-                );
+                if !short {
+                    println!(
+                        "{}\t{}\t{}\t{}\t{}s\t{}s\t{}",
+                        user.user,
+                        user.terminal,
+                        user.login_time,
+                        user.idle_time,
+                        user.jcpu,
+                        user.pcpu,
+                        user.command
+                    );
+                } else {
+                    println!(
+                        "{}\t{}\t{}\t{}",
+                        user.user,
+                        user.terminal,
+                        user.idle_time,
+                        user.command
+                    );
+                }
             }
         }
         Err(e) => {

--- a/src/uu/w/src/w.rs
+++ b/src/uu/w/src/w.rs
@@ -154,14 +154,19 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     match fetch_user_info() {
         Ok(user_info) => {
             if !no_header {
-                if !short {
-                    println!("USER\tTTY\tLOGIN@\tIDLE\tJCPU\tPCPU\tWHAT");
-                } else {
+                if short {
                     println!("USER\tTTY\tIDLE\tWHAT");
+                } else {
+                    println!("USER\tTTY\tLOGIN@\tIDLE\tJCPU\tPCPU\tWHAT");
                 }
             }
             for user in user_info {
-                if !short {
+                if short {
+                    println!(
+                        "{}\t{}\t{}\t{}",
+                        user.user, user.terminal, user.idle_time, user.command
+                    );
+                } else {
                     println!(
                         "{}\t{}\t{}\t{}\t{}s\t{}s\t{}",
                         user.user,
@@ -171,11 +176,6 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                         user.jcpu,
                         user.pcpu,
                         user.command
-                    );
-                } else {
-                    println!(
-                        "{}\t{}\t{}\t{}",
-                        user.user, user.terminal, user.idle_time, user.command
                     );
                 }
             }

--- a/src/uu/w/src/w.rs
+++ b/src/uu/w/src/w.rs
@@ -175,10 +175,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                 } else {
                     println!(
                         "{}\t{}\t{}\t{}",
-                        user.user,
-                        user.terminal,
-                        user.idle_time,
-                        user.command
+                        user.user, user.terminal, user.idle_time, user.command
                     );
                 }
             }

--- a/tests/by-util/test_w.rs
+++ b/tests/by-util/test_w.rs
@@ -26,9 +26,9 @@ fn test_option_short() {
     let cmd = new_ucmd!().arg("--short").succeeds();
 
     let cmd_output = cmd.stdout_str();
-    let cmd_output_lines: Vec<&str> = cmd_output.split("\n").collect();
+    let cmd_output_lines: Vec<&str> = cmd_output.split('\n').collect();
     let line_output_header = cmd_output_lines[0];
-    let line_output_data_words: Vec<&str> = cmd_output_lines[1].split("\t").collect();
+    let line_output_data_words: Vec<&str> = cmd_output_lines[1].split('\t').collect();
 
     assert!(line_output_header.contains("USER\tTTY\tIDLE\tWHAT"));
     assert!(!line_output_header.contains("USER\tTTY\tLOGIN@\tIDLE\tJCPU\tPCPU\tWHAT"));

--- a/tests/by-util/test_w.rs
+++ b/tests/by-util/test_w.rs
@@ -21,6 +21,32 @@ fn test_no_header() {
 }
 
 #[test]
+fn test_option_short() {
+    use regex::Regex;
+    let cmd = new_ucmd!().arg("--short").succeeds();
+
+    let cmd_output = cmd.stdout_str();
+    let cmd_output_lines: Vec<&str> = cmd_output.split("\n").collect();
+    let line_output_header = cmd_output_lines[0];
+    let line_output_data_words: Vec<&str> = cmd_output_lines[1].split("\t").collect();
+
+    assert!(line_output_header.contains("USER\tTTY\tIDLE\tWHAT"));
+    assert!(!line_output_header.contains("USER\tTTY\tLOGIN@\tIDLE\tJCPU\tPCPU\tWHAT"));
+    
+    let pattern: Vec<Regex> = vec![
+        Regex::new(r"^(\S+)").unwrap(),      // USER
+        Regex::new(r"(\S+)").unwrap(),       // TERMINAL 
+        Regex::new(r"(^$)").unwrap(),        // IDLE_TIME => empty str until IDLE_TIME implemented
+        Regex::new(r"(\d+\.\d+s)?").unwrap() // COMMAND
+    ];
+
+    assert!(pattern[0].is_match(line_output_data_words[0]));
+    assert!(pattern[1].is_match(line_output_data_words[1]));
+    assert!(pattern[2].is_match(line_output_data_words[2]));
+    assert!(pattern[3].is_match(line_output_data_words[3]));
+}
+
+#[test]
 // As of now, output is only implemented for Linux
 #[cfg(target_os = "linux")]
 fn test_output_format() {

--- a/tests/by-util/test_w.rs
+++ b/tests/by-util/test_w.rs
@@ -24,6 +24,8 @@ fn test_no_header() {
 // As of now, --short is only implemented for Linux
 #[cfg(target_os = "linux")]
 fn test_option_short() {
+    use std::io::IsTerminal;
+
     use regex::Regex;
     let cmd = new_ucmd!().arg("--short").succeeds();
 
@@ -35,17 +37,19 @@ fn test_option_short() {
     assert!(line_output_header.contains("USER\tTTY\tIDLE\tWHAT"));
     assert!(!line_output_header.contains("USER\tTTY\tLOGIN@\tIDLE\tJCPU\tPCPU\tWHAT"));
 
-    let pattern: Vec<Regex> = vec![
-        Regex::new(r"^(\S+)").unwrap(),       // USER
-        Regex::new(r"(\S+)").unwrap(),        // TERMINAL
-        Regex::new(r"(^$)").unwrap(),         // IDLE_TIME => empty str until IDLE_TIME implemented
-        Regex::new(r"(\d+\.\d+s)?").unwrap(), // COMMAND
-    ];
+    if std::io::stdout().is_terminal() {
+        let pattern: Vec<Regex> = vec![
+            Regex::new(r"^(\S+)").unwrap(),       // USER
+            Regex::new(r"(\S+)").unwrap(),        // TERMINAL
+            Regex::new(r"(^$)").unwrap(), // IDLE_TIME => empty str until IDLE_TIME implemented
+            Regex::new(r"(\d+\.\d+s)?").unwrap(), // COMMAND
+        ];
 
-    assert!(pattern[0].is_match(line_output_data_words[0]));
-    assert!(pattern[1].is_match(line_output_data_words[1]));
-    assert!(pattern[2].is_match(line_output_data_words[2]));
-    assert!(pattern[3].is_match(line_output_data_words[3]));
+        assert!(pattern[0].is_match(line_output_data_words[0]));
+        assert!(pattern[1].is_match(line_output_data_words[1]));
+        assert!(pattern[2].is_match(line_output_data_words[2]));
+        assert!(pattern[3].is_match(line_output_data_words[3]));
+    }
 }
 
 #[test]

--- a/tests/by-util/test_w.rs
+++ b/tests/by-util/test_w.rs
@@ -21,6 +21,8 @@ fn test_no_header() {
 }
 
 #[test]
+// As of now, --short is only implemented for Linux
+#[cfg(target_os = "linux")]
 fn test_option_short() {
     use regex::Regex;
     let cmd = new_ucmd!().arg("--short").succeeds();

--- a/tests/by-util/test_w.rs
+++ b/tests/by-util/test_w.rs
@@ -32,12 +32,12 @@ fn test_option_short() {
 
     assert!(line_output_header.contains("USER\tTTY\tIDLE\tWHAT"));
     assert!(!line_output_header.contains("USER\tTTY\tLOGIN@\tIDLE\tJCPU\tPCPU\tWHAT"));
-    
+
     let pattern: Vec<Regex> = vec![
-        Regex::new(r"^(\S+)").unwrap(),      // USER
-        Regex::new(r"(\S+)").unwrap(),       // TERMINAL 
-        Regex::new(r"(^$)").unwrap(),        // IDLE_TIME => empty str until IDLE_TIME implemented
-        Regex::new(r"(\d+\.\d+s)?").unwrap() // COMMAND
+        Regex::new(r"^(\S+)").unwrap(),       // USER
+        Regex::new(r"(\S+)").unwrap(),        // TERMINAL
+        Regex::new(r"(^$)").unwrap(),         // IDLE_TIME => empty str until IDLE_TIME implemented
+        Regex::new(r"(\d+\.\d+s)?").unwrap(), // COMMAND
     ];
 
     assert!(pattern[0].is_match(line_output_data_words[0]));


### PR DESCRIPTION
# Description

We check for the parameter `-s | --short`. If it is set we exclude printing of `login time`, `JCPU time` and `PCPU time`.

# Testing

Added a test to make sure only necessary values are printed.