### PR TITLE
ci: use --all-targets with clippy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - run: rustup component add clippy
-      - run: cargo clippy -- -D warnings
+      - run: cargo clippy --all-targets -- -D warnings
 
   coverage:
     name: Code Coverage


### PR DESCRIPTION
This PR adds `--all-targets` when running `clippy` to detect issues in tests, too.