### PR TITLE
util.rs: use MAIN_SEPARATOR_STR

### DIFF
--- a/tests/common/util.rs
+++ b/tests/common/util.rs
@@ -25,7 +25,7 @@ use std::os::unix::process::ExitStatusExt;
 #[cfg(windows)]
 use std::os::windows::fs::{symlink_dir, symlink_file};
 #[cfg(windows)]
-use std::path::MAIN_SEPARATOR;
+use std::path::MAIN_SEPARATOR_STR;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, ExitStatus, Output, Stdio};
 use std::rc::Rc;
@@ -993,7 +993,7 @@ impl AtPath {
 
     pub fn relative_symlink_file(&self, original: &str, link: &str) {
         #[cfg(windows)]
-        let original = original.replace('/', &MAIN_SEPARATOR.to_string());
+        let original = original.replace('/', &MAIN_SEPARATOR_STR);
         log_info(
             "symlink",
             format!("{},{}", &original, &self.plus_as_string(link)),
@@ -1015,7 +1015,7 @@ impl AtPath {
 
     pub fn relative_symlink_dir(&self, original: &str, link: &str) {
         #[cfg(windows)]
-        let original = original.replace('/', &MAIN_SEPARATOR.to_string());
+        let original = original.replace('/', &MAIN_SEPARATOR_STR);
         log_info(
             "symlink",
             format!("{},{}", &original, &self.plus_as_string(link)),


### PR DESCRIPTION
This PR replaces `MAIN_SEPARATOR.to_string()` with `MAIN_SEPARATOR_STR`.