### PR TITLE
w: add `--help`

### DIFF
--- a/src/uu/w/src/w.rs
+++ b/src/uu/w/src/w.rs
@@ -185,6 +185,12 @@ pub fn uu_app() -> Command {
         .infer_long_args(true)
         .disable_help_flag(true)
         .arg(
+            Arg::new("help")
+                .long("help")
+                .help("Print help information")
+                .action(ArgAction::Help),
+        )
+        .arg(
             Arg::new("no-header")
                 .short('h')
                 .long("no-header")

--- a/tests/by-util/test_w.rs
+++ b/tests/by-util/test_w.rs
@@ -12,6 +12,15 @@ fn test_invalid_arg() {
 }
 
 #[test]
+fn test_help() {
+    new_ucmd!()
+        .arg("--help")
+        .succeeds()
+        .stdout_contains("Usage")
+        .stdout_contains("Options");
+}
+
+#[test]
 fn test_no_header() {
     for arg in ["-h", "--no-header"] {
         let cmd = new_ucmd!().arg(arg).succeeds();

--- a/tests/by-util/test_w.rs
+++ b/tests/by-util/test_w.rs
@@ -13,11 +13,13 @@ fn test_invalid_arg() {
 
 #[test]
 fn test_no_header() {
-    let cmd = new_ucmd!().arg("--no-header").succeeds();
+    for arg in ["-h", "--no-header"] {
+        let cmd = new_ucmd!().arg(arg).succeeds();
 
-    let result = cmd.stdout_str();
+        let result = cmd.stdout_str();
 
-    assert!(!result.contains("USER\tTTY\tLOGIN@\tIDLE\tJCPU\tPCPU\tWHAT"));
+        assert!(!result.contains("USER\tTTY\tLOGIN@\tIDLE\tJCPU\tPCPU\tWHAT"));
+    }
 }
 
 #[test]


### PR DESCRIPTION
This PR adds `--help`. It also ensures that `-h` is the short form of `--no-header`.