### PR TITLE
util.rs: fix "needless_borrow" errors

### DIFF
--- a/tests/common/util.rs
+++ b/tests/common/util.rs
@@ -993,7 +993,7 @@ impl AtPath {
 
     pub fn relative_symlink_file(&self, original: &str, link: &str) {
         #[cfg(windows)]
-        let original = original.replace('/', &MAIN_SEPARATOR_STR);
+        let original = original.replace('/', MAIN_SEPARATOR_STR);
         log_info(
             "symlink",
             format!("{},{}", &original, &self.plus_as_string(link)),
@@ -1015,7 +1015,7 @@ impl AtPath {
 
     pub fn relative_symlink_dir(&self, original: &str, link: &str) {
         #[cfg(windows)]
-        let original = original.replace('/', &MAIN_SEPARATOR_STR);
+        let original = original.replace('/', MAIN_SEPARATOR_STR);
         log_info(
             "symlink",
             format!("{},{}", &original, &self.plus_as_string(link)),


### PR DESCRIPTION
This PR fixes two "needless borrow" errors I introduced with https://github.com/uutils/procps/pull/64