### PR TITLE
slabtop: add `-o`/`--once`

### DIFF
--- a/tests/by-util/test_slabtop.rs
+++ b/tests/by-util/test_slabtop.rs
@@ -3,6 +3,8 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
+#[cfg(target_os = "linux")]
+use crate::common::util::run_ucmd_as_root;
 use crate::common::util::TestScenario;
 
 #[test]
@@ -11,6 +13,61 @@ fn test_invalid_arg() {
 }
 
 #[test]
-fn test_slabtop() {
+fn test_help() {
     new_ucmd!().arg("--help").succeeds().code_is(0);
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn test_without_args_as_non_root() {
+    new_ucmd!()
+        .fails()
+        .code_is(1)
+        .stderr_contains("Permission denied");
+}
+
+// TODO: tests some temporary behavior; in the future a TUI should be used
+// if there are no args
+#[cfg(target_os = "linux")]
+#[test]
+fn test_without_args_as_root() {
+    let ts = TestScenario::new(util_name!());
+
+    if let Ok(result) = run_ucmd_as_root(&ts, &[]) {
+        result
+            .success()
+            .stdout_contains("Active / Total Objects")
+            .stdout_contains("OBJS");
+    } else {
+        print!("Test skipped; requires root user");
+    }
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn test_once_as_non_root() {
+    for arg in ["-o", "--once"] {
+        new_ucmd!()
+            .arg(arg)
+            .fails()
+            .code_is(1)
+            .stderr_contains("Permission denied");
+    }
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn test_once_as_root() {
+    let ts = TestScenario::new(util_name!());
+
+    for arg in ["-o", "--once"] {
+        if let Ok(result) = run_ucmd_as_root(&ts, &[arg]) {
+            result
+                .success()
+                .stdout_contains("Active / Total Objects")
+                .stdout_contains("OBJS");
+        } else {
+            print!("Test skipped; requires root user");
+        }
+    }
 }


### PR DESCRIPTION
This PR adds `-o`/`--once`, though the functionality itself was already there. It's the same we currently use for when there is no argument specified.