### PR TITLE
w: delete unnecessary `main.rs`

### DIFF
--- a/src/uu/w/main.rs
+++ b/src/uu/w/main.rs
@@ -1,1 +1,0 @@
-uucore::bin!(uu_w);


### PR DESCRIPTION
Currently, there are two `main.rs` files: one in `src/uu/w` and the other in `src/uu/w/src`. The first looks like it's a left-over and so this PR deletes it.