### PR TITLE
tests/util.rs: disable `unexpected_cfgs` lint

### DIFF
--- a/tests/common/util.rs
+++ b/tests/common/util.rs
@@ -5,7 +5,7 @@
 
 //spell-checker: ignore (linux) rlimit prlimit coreutil ggroups uchild uncaptured scmd SHLVL canonicalized
 
-#![allow(dead_code)]
+#![allow(dead_code, unexpected_cfgs)]
 
 use pretty_assertions::assert_eq;
 #[cfg(any(target_os = "linux", target_os = "android"))]


### PR DESCRIPTION
This PR disables the recently introduced `unexpected_cfgs` lint (see https://blog.rust-lang.org/2024/05/06/check-cfg.html) on `tests/common/util.rs` to suppress a lot of warnings because its code contains many coreutils features not available in this project (see, for example, https://github.com/uutils/procps/actions/runs/8969718428/job/24631718644?pr=70#step:5:193).