### PR TITLE
free: fix column widths for `--line`

### DIFF
--- a/src/uu/free/src/free.rs
+++ b/src/uu/free/src/free.rs
@@ -197,10 +197,10 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                 };
                 if one_line {
                     println!(
-                        "{:8}{:>12} {:8}{:>12}  {:8}{:>12} {:8}{:>12}",
+                        "{:8}{:>11} {:8}{:>11}  {:8}{:>10} {:8}{:>11}",
                         "SwapUse",
                         n2s(mem_info.swap_used),
-                        "CacheUse",
+                        "CachUse",
                         n2s(buff_cache + mem_info.reclaimable),
                         "MemUse",
                         n2s(used),


### PR DESCRIPTION
This PR adapts the column widths when using `--line` to match those of the original `free`. And it renames "CacheUse" to "CachUse".

Before change:
```
SwapUse            0 CacheUse     3952136  MemUse       3893340 MemFree      1165596
```
After change:
```
SwapUse           0 CachUse     3967332  MemUse     3857276 MemFree     1201724
```