### PR TITLE
free: remove unnecessary import

### DIFF
--- a/src/uu/free/src/free.rs
+++ b/src/uu/free/src/free.rs
@@ -14,7 +14,6 @@ use std::ops::Mul;
 use std::process;
 use std::thread::sleep;
 use std::time::Duration;
-use std::u64;
 use uucore::{error::UResult, format_usage, help_about, help_usage};
 
 const ABOUT: &str = help_about!("free.md");


### PR DESCRIPTION
This PR removes an unnecessary import to fix a clippy warning from the [legacy_numeric_constants](https://rust-lang.github.io/rust-clippy/master/index.html#/legacy_numeric_constants) lint introduced with Rust 1.79.