### PR TITLE
ci: remove clippy job from `Basic CI` workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,18 +37,6 @@ jobs:
       - run: rustup component add rustfmt
       - run: cargo fmt --all -- --check
 
-  clippy:
-    name: cargo clippy -- -D warnings
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macOS-latest, windows-latest]
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - run: rustup component add clippy
-      - run: cargo clippy --all-targets -- -D warnings
-
   coverage:
     name: Code Coverage
     runs-on: ${{ matrix.job.os }}


### PR DESCRIPTION
With the introduction of the `Code Quality` workflow the `clippy` job in the `Basic CI` workflow is no longer needed and so this PR removes it.