### PR TITLE
pidof: Implemented `-o`

### DIFF
--- a/src/uu/pidof/src/pidof.rs
+++ b/src/uu/pidof/src/pidof.rs
@@ -137,6 +137,7 @@ pub fn uu_app() -> Command {
             Arg::new("o")
                 .short('o')
                 .help("Omit results with a given PID")
+                .value_delimiter(',')
                 .action(ArgAction::Append)
                 .value_parser(clap::value_parser!(usize))
                 .value_name("omitpid"),

--- a/tests/by-util/test_pidof.rs
+++ b/tests/by-util/test_pidof.rs
@@ -37,25 +37,5 @@ fn test_no_pid_found() {
 #[test]
 #[cfg(target_os = "linux")]
 fn test_quiet() {
-    let binding = new_ucmd!().arg("kthreadd").arg("-q").succeeds();
-    let output = binding.stdout();
-
-    assert!(output.is_empty())
-}
-
-#[test]
-#[cfg(target_os = "linux")]
-fn test_s_flag() {
-    let binding = new_ucmd!()
-        .args(&["-s", "kthreadd", "kthreadd", "kthreadd"])
-        .succeeds();
-    let output = binding.stdout_str();
-
-    let binding = output.replace('\n', "");
-    let pids = binding.split(' ').collect::<Vec<_>>();
-    let first = pids[0];
-
-    let result = pids.iter().all(|it| *it == first);
-
-    assert!(result)
+    new_ucmd!().arg("kthreadd").arg("-q").succeeds().no_output();
 }

--- a/tests/by-util/test_pidof.rs
+++ b/tests/by-util/test_pidof.rs
@@ -33,3 +33,29 @@ fn test_no_program() {
 fn test_no_pid_found() {
     new_ucmd!().arg("NO_THIS_PROGRAM").fails().code_is(1);
 }
+
+#[test]
+#[cfg(target_os = "linux")]
+fn test_quiet() {
+    let binding = new_ucmd!().arg("kthreadd").arg("-q").succeeds();
+    let output = binding.stdout();
+
+    assert!(output.is_empty())
+}
+
+#[test]
+#[cfg(target_os = "linux")]
+fn test_s_flag() {
+    let binding = new_ucmd!()
+        .args(&["-s", "kthreadd", "kthreadd", "kthreadd"])
+        .succeeds();
+    let output = binding.stdout_str();
+
+    let binding = output.replace('\n', "");
+    let pids = binding.split(' ').collect::<Vec<_>>();
+    let first = pids[0];
+
+    let result = pids.iter().all(|it| *it == first);
+
+    assert!(result)
+}


### PR DESCRIPTION
fix #119 

This commit implemented two usage of `-o` which are already implemented in GNU's implementation, but not in ours.

```shell
❯ cargo run pidof zsh
116473 116472 116401 116391

❯ cargo run pidof -o116473,116472 zsh
116401 116391

❯ cargo run pidof -o116473 -o116472 zsh
116401 116391
```

And the GNU's implementation:

```shell
❯ pidof zsh
116473 116472 116401 116391

❯ pidof -o116473,116472 zsh
116401 116391

❯ pidof -o116473 -o116472 zsh
116401 116391
```