### PR TITLE
pgrep: set `args_override_self(true)`

### DIFF
--- a/src/uu/pgrep/src/pgrep.rs
+++ b/src/uu/pgrep/src/pgrep.rs
@@ -253,6 +253,7 @@ pub fn uu_app() -> Command {
         .version(crate_version!())
         .about(ABOUT)
         .override_usage(format_usage(USAGE))
+        .args_override_self(true)
         .group(ArgGroup::new("oldest_newest").args(["oldest", "newest", "inverse"]))
         .args([
             arg!(-d     --delimiter <string>    "specify output delimiter")

--- a/tests/by-util/test_pgrep.rs
+++ b/tests/by-util/test_pgrep.rs
@@ -132,6 +132,26 @@ fn test_delimiter() {
     }
 }
 
+#[cfg(target_os = "linux")]
+#[test]
+fn test_delimiter_last_wins() {
+    new_ucmd!()
+        .arg("sh")
+        .arg("-d_")
+        .arg("-d:")
+        .succeeds()
+        .stdout_does_not_contain("_")
+        .stdout_contains(":");
+
+    new_ucmd!()
+        .arg("sh")
+        .arg("-d:")
+        .arg("-d_")
+        .succeeds()
+        .stdout_does_not_contain(":")
+        .stdout_contains("_");
+}
+
 #[test]
 #[cfg(target_os = "linux")]
 fn test_ignore_case() {


### PR DESCRIPTION
This PR sets `args_override_self(true)` to allow multiple occurrences of args.