### PR TITLE
pgrep: allow `--older` without pattern

### DIFF
--- a/src/uu/pgrep/src/pgrep.rs
+++ b/src/uu/pgrep/src/pgrep.rs
@@ -6,7 +6,9 @@
 // Pid utils
 pub mod process;
 
-use clap::{arg, crate_version, Arg, ArgAction, ArgGroup, ArgMatches, Command};
+use clap::{
+    arg, crate_version, parser::ValueSource, Arg, ArgAction, ArgGroup, ArgMatches, Command,
+};
 use process::{walk_process, ProcessInformation, TerminalType};
 use regex::Regex;
 use std::{collections::HashSet, sync::OnceLock};
@@ -44,8 +46,9 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     // Pattern check
     let flag_newest = matches.get_flag("newest");
     let flag_oldest = matches.get_flag("oldest");
+    let flag_older = matches.value_source("older") == Some(ValueSource::CommandLine);
 
-    if (!flag_newest && !flag_oldest) && pattern.is_empty() {
+    if (!flag_newest && !flag_oldest && !flag_older) && pattern.is_empty() {
         return Err(USimpleError::new(
             2,
             "no matching criteria specified\nTry `pgrep --help' for more information.",

--- a/tests/by-util/test_pgrep.rs
+++ b/tests/by-util/test_pgrep.rs
@@ -95,6 +95,39 @@ fn test_newest_non_matching_pattern() {
 
 #[test]
 #[cfg(target_os = "linux")]
+fn test_older() {
+    for arg in ["-O", "--older"] {
+        new_ucmd!()
+            .arg(arg)
+            .arg("0")
+            .succeeds()
+            .stdout_matches(&Regex::new("(?m)^[1-9][0-9]*$").unwrap());
+    }
+}
+
+#[test]
+#[cfg(target_os = "linux")]
+fn test_older_matching_pattern() {
+    new_ucmd!()
+        .arg("--older=0")
+        .arg("sh")
+        .succeeds()
+        .stdout_matches(&Regex::new("(?m)^[1-9][0-9]*$").unwrap());
+}
+
+#[test]
+#[cfg(target_os = "linux")]
+fn test_older_non_matching_pattern() {
+    new_ucmd!()
+        .arg("--older=0")
+        .arg("non_matching")
+        .fails()
+        .code_is(1)
+        .no_stdout();
+}
+
+#[test]
+#[cfg(target_os = "linux")]
 fn test_full() {
     for arg in ["-f", "--full"] {
         new_ucmd!().arg("sh").arg(arg).succeeds();


### PR DESCRIPTION
This PR allows the `--older` option without a pattern: `pgrep --older=1`. This corresponds to the behavior of `pgrep` from procps-ng.