### PR TITLE
pgrep: allow `--terminal` without pattern

### DIFF
--- a/src/uu/pgrep/src/pgrep.rs
+++ b/src/uu/pgrep/src/pgrep.rs
@@ -47,8 +47,9 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let flag_newest = matches.get_flag("newest");
     let flag_oldest = matches.get_flag("oldest");
     let flag_older = matches.value_source("older") == Some(ValueSource::CommandLine);
+    let flag_terminal = matches.value_source("terminal") == Some(ValueSource::CommandLine);
 
-    if (!flag_newest && !flag_oldest && !flag_older) && pattern.is_empty() {
+    if (!flag_newest && !flag_oldest && !flag_older && !flag_terminal) && pattern.is_empty() {
         return Err(USimpleError::new(
             2,
             "no matching criteria specified\nTry `pgrep --help' for more information.",

--- a/tests/by-util/test_pgrep.rs
+++ b/tests/by-util/test_pgrep.rs
@@ -239,3 +239,26 @@ fn test_count_with_non_matching_pattern() {
         .stdout_is("0\n")
         .no_stderr();
 }
+
+#[test]
+#[cfg(target_os = "linux")]
+fn test_terminal() {
+    for arg in ["-t", "--terminal"] {
+        new_ucmd!()
+            .arg(arg)
+            .arg("tty1")
+            .arg("--inverse") // XXX hack to make test pass in CI
+            .succeeds()
+            .stdout_matches(&Regex::new("(?m)^[1-9][0-9]*$").unwrap());
+    }
+}
+
+#[test]
+#[cfg(target_os = "linux")]
+fn test_terminal_invalid_terminal() {
+    new_ucmd!()
+        .arg("--terminal=invalid")
+        .fails()
+        .code_is(1)
+        .no_output();
+}


### PR DESCRIPTION
Fixes #135 