### PR TITLE
pgrep: allow comma-separated list of terminals

### DIFF
--- a/src/uu/pgrep/src/pgrep.rs
+++ b/src/uu/pgrep/src/pgrep.rs
@@ -286,7 +286,7 @@ pub fn uu_app() -> Command {
             // arg!(-P     --parent <PPID>         "match only child processes of the given parent"),
             // arg!(-s     --session <SID>         "match session IDs"),
             arg!(-t     --terminal <tty>        "match by controlling terminal")
-                .action(ArgAction::Append),
+                .value_delimiter(','),
             // arg!(-u     --euid <ID>         ... "match by effective IDs"),
             // arg!(-U     --uid <ID>          ... "match by real IDs"),
             arg!(-x     --exact                 "match exactly with the command name"),

--- a/tests/by-util/test_pgrep.rs
+++ b/tests/by-util/test_pgrep.rs
@@ -253,8 +253,18 @@ fn test_terminal() {
     }
 }
 
-#[cfg(target_os = "linux")]
 #[test]
+#[cfg(target_os = "linux")]
+fn test_terminal_multiple_terminals() {
+    new_ucmd!()
+        .arg("--terminal=tty1,?")
+        .arg("kthreadd")
+        .succeeds()
+        .stdout_matches(&Regex::new(SINGLE_PID).unwrap());
+}
+
+#[test]
+#[cfg(target_os = "linux")]
 fn test_unknown_terminal() {
     new_ucmd!().arg("--terminal=?").succeeds();
     new_ucmd!().arg("--terminal=?").arg("kthreadd").succeeds();


### PR DESCRIPTION
This PR allows a comma-separated list of terminals for `--terminal`.