### PR TITLE
pgrep: allow `--runstates` without pattern

### DIFF
--- a/src/uu/pgrep/src/pgrep.rs
+++ b/src/uu/pgrep/src/pgrep.rs
@@ -71,6 +71,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     if (!settings.newest
         && !settings.oldest
+        && settings.runstates.is_none()
         && settings.older.is_none()
         && settings.terminal.is_none())
         && pattern.is_empty()
@@ -168,6 +169,7 @@ fn collect_matched_pids(settings: &Settings) -> Vec<ProcessInformation> {
                 (Some(arg_run_states), Ok(pid_state)) => {
                     arg_run_states.contains(&pid_state.to_string())
                 }
+                (_, Err(_)) => false,
                 _ => true,
             };
 

--- a/tests/by-util/test_pgrep.rs
+++ b/tests/by-util/test_pgrep.rs
@@ -9,6 +9,9 @@ use regex::Regex;
 
 #[cfg(target_os = "linux")]
 const SINGLE_PID: &str = "^[1-9][0-9]*";
+#[cfg(target_os = "linux")]
+// (?m) enables multi-line mode
+const MULTIPLE_PIDS: &str = "(?m)^[1-9][0-9]*$";
 
 #[test]
 fn test_no_args() {
@@ -101,7 +104,7 @@ fn test_older() {
             .arg(arg)
             .arg("0")
             .succeeds()
-            .stdout_matches(&Regex::new("(?m)^[1-9][0-9]*$").unwrap());
+            .stdout_matches(&Regex::new(MULTIPLE_PIDS).unwrap());
     }
 }
 
@@ -112,7 +115,7 @@ fn test_older_matching_pattern() {
         .arg("--older=0")
         .arg("sh")
         .succeeds()
-        .stdout_matches(&Regex::new("(?m)^[1-9][0-9]*$").unwrap());
+        .stdout_matches(&Regex::new(MULTIPLE_PIDS).unwrap());
 }
 
 #[test]
@@ -249,7 +252,7 @@ fn test_terminal() {
             .arg("tty1")
             .arg("--inverse") // XXX hack to make test pass in CI
             .succeeds()
-            .stdout_matches(&Regex::new("(?m)^[1-9][0-9]*$").unwrap());
+            .stdout_matches(&Regex::new(MULTIPLE_PIDS).unwrap());
     }
 }
 
@@ -288,7 +291,7 @@ fn test_runstates() {
             .arg(arg)
             .arg("S")
             .succeeds()
-            .stdout_matches(&Regex::new("(?m)^[1-9][0-9]*$").unwrap());
+            .stdout_matches(&Regex::new(MULTIPLE_PIDS).unwrap());
     }
 }
 

--- a/tests/by-util/test_pgrep.rs
+++ b/tests/by-util/test_pgrep.rs
@@ -279,3 +279,25 @@ fn test_terminal_invalid_terminal() {
         .code_is(1)
         .no_output();
 }
+
+#[test]
+#[cfg(target_os = "linux")]
+fn test_runstates() {
+    for arg in ["-r", "--runstates"] {
+        new_ucmd!()
+            .arg(arg)
+            .arg("S")
+            .succeeds()
+            .stdout_matches(&Regex::new("(?m)^[1-9][0-9]*$").unwrap());
+    }
+}
+
+#[test]
+#[cfg(target_os = "linux")]
+fn test_runstates_invalid_runstate() {
+    new_ucmd!()
+        .arg("--runstates=invalid")
+        .fails()
+        .code_is(1)
+        .no_output();
+}


### PR DESCRIPTION
This PR allows the use of `--runstates` without a pattern. It also turns a regex pattern into a `const` in the tests.