### PR TITLE
free: remove two tests & refactor remaining tests

### DIFF
--- a/tests/by-util/test_free.rs
+++ b/tests/by-util/test_free.rs
@@ -17,15 +17,50 @@ fn test_invalid_arg() {
 
 #[test]
 fn test_no_args() {
-    let result = new_ucmd!().succeeds();
-    assert!(result.stdout_str().contains("Mem:"));
+    let re_head_str = r"^ {15}total {8}used {8}free {6}shared {2}buff/cache {3}available$";
+    let re_mem_str = r"^Mem:( +\d+){6}$";
+    let re_swap_str = r"^Swap: ( +\d+){3}$";
+
+    let re_list = vec![
+        Regex::new(re_head_str).unwrap(),
+        Regex::new(re_mem_str).unwrap(),
+        Regex::new(re_swap_str).unwrap(),
+    ];
+
+    let binding = new_ucmd!().succeeds();
+    let free_result = binding.stdout_str();
+    assert_eq!(free_result.len(), 207);
+
+    // Check the format for each line output
+    let mut free_lines = free_result.split('\n');
+    for re in re_list {
+        assert!(re.is_match(free_lines.next().unwrap()));
+    }
 }
 
 #[test]
 fn test_wide() {
-    let result = new_ucmd!().arg("--wide").succeeds();
-    assert!(result.stdout_str().contains("Mem:"));
-    assert!(!result.stdout_str().contains("buff/cache"));
+    let re_head_str = r"^ {15}total {8}used {8}free {6}shared {5}buffers {7}cache {3}available$";
+    let re_mem_str = r"^Mem:( +\d+){7}$";
+    let re_swap_str = r"^Swap: ( +\d+){3}$";
+
+    let re_list = vec![
+        Regex::new(re_head_str).unwrap(),
+        Regex::new(re_mem_str).unwrap(),
+        Regex::new(re_swap_str).unwrap(),
+    ];
+
+    let binding = new_ucmd!().arg("--wide").succeeds();
+    let free_result = binding.stdout_str();
+
+    // The total number of character is always fixed
+    assert_eq!(free_result.len(), 231);
+
+    // Check the format for each line output
+    let mut free_lines = free_result.split('\n');
+    for re in re_list {
+        assert!(re.is_match(free_lines.next().unwrap()));
+    }
 }
 
 #[test]
@@ -74,52 +109,4 @@ fn test_always_one_line() {
     let stdout = result.stdout_str().lines().collect::<Vec<&str>>();
     assert_eq!(stdout.len(), 1);
     assert!(stdout[0].starts_with("SwapUse"));
-}
-
-#[test]
-fn test_column_format() {
-    let re_head_str = r"^ {15}total {8}used {8}free {6}shared {2}buff/cache {3}available$";
-    let re_mem_str = r"^Mem:( +\d+){6}$";
-    let re_swap_str = r"^Swap: ( +\d+){3}$";
-
-    let re_list = vec![
-        Regex::new(re_head_str).unwrap(),
-        Regex::new(re_mem_str).unwrap(),
-        Regex::new(re_swap_str).unwrap(),
-    ];
-
-    let binding = new_ucmd!().succeeds();
-    let free_result = binding.stdout_str();
-    assert_eq!(free_result.len(), 207);
-
-    // Check the format for each line output
-    let mut free_lines = free_result.split('\n');
-    for re in re_list {
-        assert!(re.is_match(free_lines.next().unwrap()));
-    }
-}
-
-#[test]
-fn test_wide_column_format() {
-    let re_head_str = r"^ {15}total {8}used {8}free {6}shared {5}buffers {7}cache {3}available$";
-    let re_mem_str = r"^Mem:( +\d+){7}$";
-    let re_swap_str = r"^Swap: ( +\d+){3}$";
-
-    let re_list = vec![
-        Regex::new(re_head_str).unwrap(),
-        Regex::new(re_mem_str).unwrap(),
-        Regex::new(re_swap_str).unwrap(),
-    ];
-
-    let binding = new_ucmd!().arg("--wide").succeeds();
-    let free_result = binding.stdout_str();
-
-    // The total number of character is always fixed
-    assert_eq!(free_result.len(), 231);
-
-    // Check the format for each line output
-    let mut free_lines = free_result.split('\n');
-    for re in re_list {
-        assert!(re.is_match(free_lines.next().unwrap()));
-    }
 }

--- a/tests/by-util/test_free.rs
+++ b/tests/by-util/test_free.rs
@@ -32,7 +32,7 @@ fn test_no_args() {
     assert_eq!(free_result.len(), 207);
 
     // Check the format for each line output
-    let mut free_lines = free_result.split('\n');
+    let mut free_lines = free_result.lines();
     for re in re_list {
         assert!(re.is_match(free_lines.next().unwrap()));
     }
@@ -57,7 +57,7 @@ fn test_wide() {
     assert_eq!(free_result.len(), 231);
 
     // Check the format for each line output
-    let mut free_lines = free_result.split('\n');
+    let mut free_lines = free_result.lines();
     for re in re_list {
         assert!(re.is_match(free_lines.next().unwrap()));
     }

--- a/tests/by-util/test_free.rs
+++ b/tests/by-util/test_free.rs
@@ -17,49 +17,49 @@ fn test_invalid_arg() {
 
 #[test]
 fn test_no_args() {
-    let re_head_str = r"^ {15}total {8}used {8}free {6}shared {2}buff/cache {3}available$";
-    let re_mem_str = r"^Mem:( +\d+){6}$";
-    let re_swap_str = r"^Swap: ( +\d+){3}$";
+    let header_pattern = r"^ {15}total {8}used {8}free {6}shared {2}buff/cache {3}available$";
+    let mem_pattern = r"^Mem:( +\d+){6}$";
+    let swap_pattern = r"^Swap: ( +\d+){3}$";
 
-    let re_list = vec![
-        Regex::new(re_head_str).unwrap(),
-        Regex::new(re_mem_str).unwrap(),
-        Regex::new(re_swap_str).unwrap(),
+    let patterns = vec![
+        Regex::new(header_pattern).unwrap(),
+        Regex::new(mem_pattern).unwrap(),
+        Regex::new(swap_pattern).unwrap(),
     ];
 
     let binding = new_ucmd!().succeeds();
-    let free_result = binding.stdout_str();
-    assert_eq!(free_result.len(), 207);
+    let output = binding.stdout_str();
+    assert_eq!(output.len(), 207);
 
     // Check the format for each line output
-    let mut free_lines = free_result.lines();
-    for re in re_list {
-        assert!(re.is_match(free_lines.next().unwrap()));
+    let mut lines = output.lines();
+    for pattern in patterns {
+        assert!(pattern.is_match(lines.next().unwrap()));
     }
 }
 
 #[test]
 fn test_wide() {
-    let re_head_str = r"^ {15}total {8}used {8}free {6}shared {5}buffers {7}cache {3}available$";
-    let re_mem_str = r"^Mem:( +\d+){7}$";
-    let re_swap_str = r"^Swap: ( +\d+){3}$";
+    let header_pattern = r"^ {15}total {8}used {8}free {6}shared {5}buffers {7}cache {3}available$";
+    let mem_pattern = r"^Mem:( +\d+){7}$";
+    let swap_pattern = r"^Swap: ( +\d+){3}$";
 
-    let re_list = vec![
-        Regex::new(re_head_str).unwrap(),
-        Regex::new(re_mem_str).unwrap(),
-        Regex::new(re_swap_str).unwrap(),
+    let patterns = vec![
+        Regex::new(header_pattern).unwrap(),
+        Regex::new(mem_pattern).unwrap(),
+        Regex::new(swap_pattern).unwrap(),
     ];
 
     let binding = new_ucmd!().arg("--wide").succeeds();
-    let free_result = binding.stdout_str();
+    let output = binding.stdout_str();
 
     // The total number of character is always fixed
-    assert_eq!(free_result.len(), 231);
+    assert_eq!(output.len(), 231);
 
     // Check the format for each line output
-    let mut free_lines = free_result.lines();
-    for re in re_list {
-        assert!(re.is_match(free_lines.next().unwrap()));
+    let mut lines = output.lines();
+    for pattern in patterns {
+        assert!(pattern.is_match(lines.next().unwrap()));
     }
 }
 

--- a/tests/by-util/test_free.rs
+++ b/tests/by-util/test_free.rs
@@ -50,29 +50,33 @@ fn test_wide() {
         Regex::new(swap_pattern).unwrap(),
     ];
 
-    let binding = new_ucmd!().arg("--wide").succeeds();
-    let output = binding.stdout_str();
+    for arg in ["-w", "--wide"] {
+        let binding = new_ucmd!().arg(arg).succeeds();
+        let output = binding.stdout_str();
 
-    // The total number of character is always fixed
-    assert_eq!(output.len(), 231);
+        // The total number of character is always fixed
+        assert_eq!(output.len(), 231);
 
-    // Check the format for each line output
-    let mut lines = output.lines();
-    for pattern in patterns {
-        assert!(pattern.is_match(lines.next().unwrap()));
+        // Check the format for each line output
+        let mut lines = output.lines();
+        for pattern in &patterns {
+            assert!(pattern.is_match(lines.next().unwrap()));
+        }
     }
 }
 
 #[test]
 fn test_total() {
-    let result = new_ucmd!().arg("-t").succeeds();
-    assert_eq!(result.stdout_str().lines().count(), 4);
-    assert!(result
-        .stdout_str()
-        .lines()
-        .last()
-        .unwrap()
-        .starts_with("Total:"))
+    for arg in ["-t", "--total"] {
+        let result = new_ucmd!().arg(arg).succeeds();
+        assert_eq!(result.stdout_str().lines().count(), 4);
+        assert!(result
+            .stdout_str()
+            .lines()
+            .last()
+            .unwrap()
+            .starts_with("Total:"))
+    }
 }
 
 #[test]
@@ -83,23 +87,27 @@ fn test_count() {
 
 #[test]
 fn test_lohi() {
-    let result = new_ucmd!().arg("--lohi").succeeds();
-    assert_eq!(result.stdout_str().lines().count(), 5);
-    let lines = result.stdout_str().lines().collect::<Vec<&str>>();
-    assert!(lines[2].starts_with("Low:"));
-    assert!(lines[3].starts_with("High:"));
+    for arg in ["-l", "--lohi"] {
+        let result = new_ucmd!().arg(arg).succeeds();
+        assert_eq!(result.stdout_str().lines().count(), 5);
+        let lines = result.stdout_str().lines().collect::<Vec<&str>>();
+        assert!(lines[2].starts_with("Low:"));
+        assert!(lines[3].starts_with("High:"));
+    }
 }
 
 #[test]
 fn test_committed() {
-    let result = new_ucmd!().arg("-v").succeeds();
-    assert_eq!(result.stdout_str().lines().count(), 4);
-    assert!(result
-        .stdout_str()
-        .lines()
-        .last()
-        .unwrap()
-        .starts_with("Comm:"))
+    for arg in ["-v", "--committed"] {
+        let result = new_ucmd!().arg(arg).succeeds();
+        assert_eq!(result.stdout_str().lines().count(), 4);
+        assert!(result
+            .stdout_str()
+            .lines()
+            .last()
+            .unwrap()
+            .starts_with("Comm:"))
+    }
 }
 
 #[test]


### PR DESCRIPTION
This PR removes two redundant tests and applies some refactorings to the remaining tests:

* rename many vars
* use `lines()` instead of `split('\n')`
* test both short and long options

For reviewing, it's probably best to look at the commits in chronological order.