### PR TITLE
ci: remove unused `CARGO_FEATURES_OPTION`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,8 +63,6 @@ jobs:
         if [ -n "${{ matrix.job.toolchain }}" ]; then TOOLCHAIN="${{ matrix.job.toolchain }}" ; fi
         outputs TOOLCHAIN
         # target-specific options
-        # * CARGO_FEATURES_OPTION
-        CARGO_FEATURES_OPTION='--all -- --check' ;  ## default to '--all-features' for code coverage
         # * CODECOV_FLAGS
         CODECOV_FLAGS=$( echo "${{ matrix.job.os }}" | sed 's/[^[:alnum:]]/_/g' )
         outputs CODECOV_FLAGS
@@ -72,7 +70,7 @@ jobs:
     - name: rust toolchain ~ install
       uses: dtolnay/rust-toolchain@nightly
     - name: Test
-      run: cargo test ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }} --no-fail-fast
+      run: cargo test --no-fail-fast
       env:
         CARGO_INCREMENTAL: "0"
         RUSTC_WRAPPER: ""


### PR DESCRIPTION
This PR removes `CARGO_FEATURES_OPTION` from the "Code Coverage" jobs because when it's used it is always empty.