### PR TITLE
pwdx: handle `0` as invalid PID

### DIFF
--- a/tests/by-util/test_pwdx.rs
+++ b/tests/by-util/test_pwdx.rs
@@ -6,6 +6,18 @@
 use crate::common::util::TestScenario;
 
 #[test]
+fn test_invalid_pid() {
+    for invalid_pid in ["0", "invalid"] {
+        new_ucmd!()
+            .arg(invalid_pid)
+            .fails()
+            .code_is(1)
+            .no_stdout()
+            .stderr_contains(format!("invalid process id: {invalid_pid}"));
+    }
+}
+
+#[test]
 fn test_invalid_arg() {
     new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
 }


### PR DESCRIPTION
This PR changes the error message that's shown when `pwdx 0` is called. Now it matches the error message shown by the original `pwdx`
```
// before
$ cargo run pwdx 0
pwdx: failed to read link for PID 0: No such file or directory (os error 2)

// after
$ cargo run pwdx 0
pwdx: invalid process id: 0
```