### PR TITLE
ps: remove dead code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1056,7 +1056,6 @@ dependencies = [
  "libc",
  "nix 0.29.0",
  "prettytable-rs",
- "thiserror",
  "uu_pgrep",
  "uucore",
 ]

--- a/src/uu/ps/Cargo.toml
+++ b/src/uu/ps/Cargo.toml
@@ -18,7 +18,6 @@ chrono = { workspace = true, default-features = false, features = ["clock"] }
 libc = { workspace = true }
 prettytable-rs = { workspace = true }
 nix = { workspace = true }
-thiserror = { workspace = true }
 
 uu_pgrep = { path = "../pgrep" }
 

--- a/src/uu/ps/src/parser.rs
+++ b/src/uu/ps/src/parser.rs
@@ -4,16 +4,6 @@
 // file that was distributed with this source code.
 
 use std::convert::Infallible;
-use thiserror::Error as TError;
-
-#[derive(Debug, TError, PartialEq, Eq)]
-pub enum Error {
-    #[error("empty value")]
-    EmptyValue,
-
-    #[error("parsing failed")]
-    ParsingFailed,
-}
 
 /// Parsing _**optional**_ key-value arguments
 ///
@@ -53,34 +43,12 @@ impl OptionalKeyValue {
         }
     }
 
-    pub fn with_key<T>(key: T) -> Self
-    where
-        T: Into<String>,
-    {
-        Self {
-            key: key.into(),
-            value: None,
-        }
-    }
-
     pub fn key(&self) -> &str {
         &self.key
     }
 
     pub fn value(&self) -> &Option<String> {
         &self.value
-    }
-
-    pub fn is_value_empty(&self) -> bool {
-        self.value.is_none()
-    }
-
-    pub fn try_get<T: std::str::FromStr>(&self) -> Result<T, Error> {
-        let Some(ref value) = self.value else {
-            return Err(Error::EmptyValue);
-        };
-
-        value.parse::<T>().map_err(|_| Error::ParsingFailed)
     }
 }
 
@@ -102,35 +70,9 @@ mod tests {
     }
 
     #[test]
-    fn test_parsing() {
-        assert!(new("value").is_value_empty());
-        assert!(!new("value=").is_value_empty());
-        assert!(!new("value=v").is_value_empty());
-        assert!(!new("value=?:").is_value_empty());
-
-        assert!(OptionalKeyValue::with_key("key").key().eq("key"));
-    }
-
-    #[test]
     fn test_get_key() {
         assert_eq!(new("value").key(), "value");
         assert_eq!(new("value=").key(), "value");
         assert_eq!(new("value=?").key(), "value");
-    }
-
-    #[test]
-    fn test_get_value() {
-        // String test
-        assert_eq!(new("value").try_get::<String>(), Err(Error::EmptyValue));
-        assert_eq!(new("value=").try_get::<String>(), Ok("".into()));
-        assert_eq!(new("value=?").try_get::<String>(), Ok("?".into()));
-
-        // Number test
-        assert_eq!(new("value").try_get::<usize>(), Err(Error::EmptyValue));
-        assert_eq!(new("value=0").try_get::<usize>(), Ok(0));
-        assert_eq!(new("value=0").try_get::<i128>(), Ok(0));
-        assert_eq!(new("value=-1").try_get::<i128>(), Ok(-1));
-        assert_eq!(new("value=0").try_get::<u128>(), Ok(0));
-        assert_eq!(new("value=-1").try_get::<u128>(), Err(Error::ParsingFailed));
     }
 }


### PR DESCRIPTION
Rust `1.80.1` shows some "dead code" warnings (see https://github.com/uutils/procps/actions/runs/10304214964/job/28522100251?pr=168#step:7:236):
```
error: variants `EmptyValue` and `ParsingFailed` are never constructed
  --> src/uu/ps/src/parser.rs:12:5
   |
10 | pub enum Error {
   |          ----- variants in this enum
11 |     #[error("empty value")]
12 |     EmptyValue,
   |     ^^^^^^^^^^
...
15 |     ParsingFailed,
   |     ^^^^^^^^^^^^^
   |
   = note: `Error` has a derived impl for the trait `Debug`, but this is intentionally ignored during dead code analysis
   = note: `-D dead-code` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(dead_code)]`

error: associated items `with_key`, `is_value_empty`, and `try_get` are never used
  --> src/uu/ps/src/parser.rs:56:12
   |
36 | impl OptionalKeyValue {
   | --------------------- associated items in this implementation
...
56 |     pub fn with_key<T>(key: T) -> Self
   |            ^^^^^^^^
...
74 |     pub fn is_value_empty(&self) -> bool {
   |            ^^^^^^^^^^^^^^
...
78 |     pub fn try_get<T: std::str::FromStr>(&self) -> Result<T, Error> {
   |            ^^^^^^^
```
This PR fixes those warnings by removing the unused code.