### PR TITLE
pwdx: use `sysinfo` crate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,12 +69,20 @@ jobs:
 
     - name: rust toolchain ~ install
       uses: dtolnay/rust-toolchain@nightly
+    - name: set RUSTFLAGS
+      shell: bash
+      run: |
+        if [ "$RUNNER_OS" == "Windows" ]; then
+          # -Clink-dead-code conflicts with sysinfo crate and leads to STATUS_DLL_NOT_FOUND error, so we don't use it on Windows
+          echo "RUSTFLAGS=-Zprofile -Ccodegen-units=1 -Copt-level=0 -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort" >> $GITHUB_ENV
+        else
+          echo "RUSTFLAGS=-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort" >> $GITHUB_ENV
+        fi
     - name: Test
       run: cargo test --no-fail-fast
       env:
         CARGO_INCREMENTAL: "0"
         RUSTC_WRAPPER: ""
-        RUSTFLAGS: "-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort"
         RUSTDOCFLAGS: "-Cpanic=abort"
     - name: "`grcov` ~ install"
       id: build_grcov

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1065,6 +1065,7 @@ name = "uu_pwdx"
 version = "0.0.1"
 dependencies = [
  "clap",
+ "sysinfo",
  "uucore",
 ]
 

--- a/src/uu/pwdx/Cargo.toml
+++ b/src/uu/pwdx/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["command-line-utilities"]
 [dependencies]
 uucore = { workspace = true }
 clap = { workspace = true }
+sysinfo = { workspace = true }
 
 [lib]
 path = "src/pwdx.rs"

--- a/tests/by-util/test_pwdx.rs
+++ b/tests/by-util/test_pwdx.rs
@@ -3,10 +3,8 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
-#[cfg(target_os = "linux")]
 use std::process;
 
-#[cfg(target_os = "linux")]
 use regex::Regex;
 
 use crate::common::util::TestScenario;
@@ -17,7 +15,6 @@ fn test_no_args() {
 }
 
 #[test]
-#[cfg(target_os = "linux")]
 fn test_valid_pid() {
     let pid = process::id();
 
@@ -28,7 +25,6 @@ fn test_valid_pid() {
 }
 
 #[test]
-#[cfg(target_os = "linux")]
 fn test_multiple_valid_pids() {
     let pid = process::id();
 
@@ -38,6 +34,40 @@ fn test_multiple_valid_pids() {
         .succeeds()
         // (?m) enables multi-line mode
         .stdout_matches(&Regex::new(&format!("(?m)^{pid}: .+$")).unwrap());
+}
+
+#[test]
+fn test_non_existing_pid() {
+    let non_existing_pid = "999999";
+
+    new_ucmd!()
+        .arg(non_existing_pid)
+        .fails()
+        .code_is(1)
+        .no_stdout()
+        .stderr_is(format!("{non_existing_pid}: No such process\n"));
+}
+
+#[test]
+fn test_non_existing_and_existing_pid() {
+    let pid = process::id();
+    let non_existing_pid = "999999";
+
+    new_ucmd!()
+        .arg(non_existing_pid)
+        .arg(pid.to_string())
+        .fails()
+        .code_is(1)
+        .stdout_matches(&Regex::new(&format!("^{pid}: .+\n$")).unwrap())
+        .stderr_is(format!("{non_existing_pid}: No such process\n"));
+
+    new_ucmd!()
+        .arg(pid.to_string())
+        .arg(non_existing_pid)
+        .fails()
+        .code_is(1)
+        .stdout_matches(&Regex::new(&format!("^{pid}: .+\n$")).unwrap())
+        .stderr_is(format!("{non_existing_pid}: No such process\n"));
 }
 
 #[test]
@@ -53,7 +83,6 @@ fn test_invalid_pid() {
 }
 
 #[test]
-#[cfg(target_os = "linux")]
 fn test_invalid_and_valid_pid() {
     let pid = process::id();
     let invalid_pid = "invalid";


### PR DESCRIPTION
This PR uses the `sysinfo` crate to get the working directories of processes in a platform-independent way.