### PR TITLE
ci: run `semicolon_if_nothing_returned` lint

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -103,7 +103,7 @@ jobs:
           command: |
             ## `cargo clippy` lint testing
             unset fault
-            CLIPPY_FLAGS="-W clippy::default_trait_access -W clippy::manual_string_new -W clippy::cognitive_complexity -W clippy::implicit_clone -W clippy::range-plus-one -W clippy::redundant-clone -W clippy::match_bool"
+            CLIPPY_FLAGS="-W clippy::default_trait_access -W clippy::manual_string_new -W clippy::cognitive_complexity -W clippy::implicit_clone -W clippy::range-plus-one -W clippy::redundant-clone -W clippy::match_bool -W clippy::semicolon_if_nothing_returned"
             fault_type="${{ steps.vars.outputs.FAULT_TYPE }}"
             fault_prefix=$(echo "$fault_type" | tr '[:lower:]' '[:upper:]')
             # * convert any warnings to GHA UI annotations; ref: <https://help.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-a-warning-message>

--- a/src/uu/free/src/free.rs
+++ b/src/uu/free/src/free.rs
@@ -217,7 +217,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                             n2s(mem_info.shared),
                             n2s(buff_cache + mem_info.reclaimable),
                             n2s(mem_info.available),
-                        )
+                        );
                     }
 
                     if lohi {
@@ -391,5 +391,5 @@ fn header() {
     println!(
         "{:8}{:>12}{:>12}{:>12}{:>12}{:>12}{:>12}",
         " ", "total", "used", "free", "shared", "buff/cache", "available",
-    )
+    );
 }

--- a/src/uu/pgrep/src/pgrep.rs
+++ b/src/uu/pgrep/src/pgrep.rs
@@ -227,7 +227,7 @@ fn collect_matched_pids(settings: &Settings) -> Vec<ProcessInformation> {
                 && parent_matched)
                 ^ settings.inverse
             {
-                tmp_vec.push(pid)
+                tmp_vec.push(pid);
             }
         }
         tmp_vec
@@ -264,9 +264,9 @@ fn process_flag_o_n(
             .collect::<Vec<_>>();
 
         if settings.newest {
-            filtered.sort_by(|a, b| b.pid.cmp(&a.pid))
+            filtered.sort_by(|a, b| b.pid.cmp(&a.pid));
         } else {
-            filtered.sort_by(|a, b| a.pid.cmp(&b.pid))
+            filtered.sort_by(|a, b| a.pid.cmp(&b.pid));
         }
 
         vec![filtered.first().cloned().unwrap().clone()]

--- a/src/uu/pidof/src/pidof.rs
+++ b/src/uu/pidof/src/pidof.rs
@@ -84,7 +84,7 @@ fn collect_matched_pids(matches: &ArgMatches) -> Vec<ProcessInformation> {
                 let should_omit = arg_omit_pid.contains(&process.pid);
 
                 if contains && !should_omit {
-                    processed.push(process)
+                    processed.push(process);
                 }
             }
 

--- a/src/uu/pidwait/src/pidwait.rs
+++ b/src/uu/pidwait/src/pidwait.rs
@@ -84,17 +84,17 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     // Process outputs
     if settings.count {
-        println!("{}", proc_infos.len())
+        println!("{}", proc_infos.len());
     }
 
     if settings.echo {
         if settings.newest || settings.oldest {
             for ele in &proc_infos {
-                println!("waiting for  (pid {})", ele.pid)
+                println!("waiting for  (pid {})", ele.pid);
             }
         } else {
             for ele in proc_infos.iter_mut() {
-                println!("waiting for {} (pid {})", ele.status()["Name"], ele.pid)
+                println!("waiting for {} (pid {})", ele.status()["Name"], ele.pid);
             }
         }
     }
@@ -162,7 +162,7 @@ fn collect_proc_infos(settings: &Settings) -> Vec<ProcessInformation> {
                 REGEX.get().unwrap().is_match(want)
             };
             if matched {
-                temp.push(it)
+                temp.push(it);
             }
         }
         temp
@@ -174,7 +174,7 @@ fn collect_proc_infos(settings: &Settings) -> Vec<ProcessInformation> {
         let older = settings.older.unwrap_or_default();
         for mut proc_info in proc_infos {
             if proc_info.start_time().unwrap() >= older {
-                temp.push(proc_info)
+                temp.push(proc_info);
             }
         }
         temp
@@ -217,9 +217,9 @@ fn collect_proc_infos(settings: &Settings) -> Vec<ProcessInformation> {
             .collect::<Vec<_>>();
 
         if settings.newest {
-            filtered.sort_by(|a, b| b.pid.cmp(&a.pid))
+            filtered.sort_by(|a, b| b.pid.cmp(&a.pid));
         } else {
-            filtered.sort_by(|a, b| a.pid.cmp(&b.pid))
+            filtered.sort_by(|a, b| a.pid.cmp(&b.pid));
         }
 
         vec![filtered.first().cloned().unwrap().clone()]

--- a/src/uu/pidwait/src/wait.rs
+++ b/src/uu/pidwait/src/wait.rs
@@ -17,7 +17,7 @@ pub(crate) fn wait(procs: &[ProcessInformation]) {
         for proc in &list.clone() {
             // Check is running
             if !is_running(proc.pid) {
-                list.retain(|it| it.pid != proc.pid)
+                list.retain(|it| it.pid != proc.pid);
             }
         }
 

--- a/src/uu/ps/src/collector.rs
+++ b/src/uu/ps/src/collector.rs
@@ -48,7 +48,7 @@ pub(crate) fn basic_collector(
         let proc_ttys = proc_info.borrow().tty();
 
         if proc_ttys == current_tty {
-            result.push(proc_info.clone())
+            result.push(proc_info.clone());
         }
     }
 
@@ -66,7 +66,7 @@ pub(crate) fn process_collector(
 
     // flag `-A`
     if matches.get_flag("A") {
-        result.extend(proc_snapshot.iter().map(Rc::clone))
+        result.extend(proc_snapshot.iter().map(Rc::clone));
     }
 
     result
@@ -99,7 +99,7 @@ pub(crate) fn session_collector(
             if let Some(sid) = getsid(pid as i32) {
                 // Check is session leader
                 if sid != (pid as i32) && tty(it) != Teletype::Unknown {
-                    result.push(it.clone())
+                    result.push(it.clone());
                 }
             }
         });

--- a/src/uu/ps/src/sorting.rs
+++ b/src/uu/ps/src/sorting.rs
@@ -9,10 +9,10 @@ use uu_pgrep::process::ProcessInformation;
 
 // TODO: Implementing sorting flags.
 pub(crate) fn sort(input: &mut [Rc<RefCell<ProcessInformation>>], _matches: &ArgMatches) {
-    sort_by_pid(input)
+    sort_by_pid(input);
 }
 
 /// Sort by pid. (Default)
 fn sort_by_pid(input: &mut [Rc<RefCell<ProcessInformation>>]) {
-    input.sort_by(|a, b| a.borrow().pid.cmp(&b.borrow().pid))
+    input.sort_by(|a, b| a.borrow().pid.cmp(&b.borrow().pid));
 }

--- a/src/uu/slabtop/src/parse.rs
+++ b/src/uu/slabtop/src/parse.rs
@@ -123,7 +123,7 @@ impl SlabInfo {
                         } else {
                             Ordering::Equal
                         }
-                    })
+                    });
                 }
             }
 

--- a/tests/by-util/test_free.rs
+++ b/tests/by-util/test_free.rs
@@ -75,7 +75,7 @@ fn test_total() {
             .lines()
             .last()
             .unwrap()
-            .starts_with("Total:"))
+            .starts_with("Total:"));
     }
 }
 
@@ -106,7 +106,7 @@ fn test_committed() {
             .lines()
             .last()
             .unwrap()
-            .starts_with("Comm:"))
+            .starts_with("Comm:"));
     }
 }
 

--- a/tests/by-util/test_w.rs
+++ b/tests/by-util/test_w.rs
@@ -88,6 +88,6 @@ fn test_output_format() {
         );
         // Assert that there is something in the JCPU and PCPU slots,
         // this will need to be changed when IDLE is implemented
-        assert!(!line_vec[3].is_empty() && !line_vec[4].is_empty())
+        assert!(!line_vec[3].is_empty() && !line_vec[4].is_empty());
     }
 }


### PR DESCRIPTION
This PR runs the [semicolon_if_nothing_returned](https://rust-lang.github.io/rust-clippy/master/index.html#/semicolon_if_nothing_returned) lint in the CI and adds missing semicolons.