### PR TITLE
pmap: fix address column

### DIFF
--- a/src/uu/pmap/src/pmap.rs
+++ b/src/uu/pmap/src/pmap.rs
@@ -54,7 +54,6 @@ fn parse_maps(pid: &str) -> Result<(), Error> {
     let path = format!("/proc/{}/maps", pid);
     let contents = fs::read_to_string(path)?;
 
-    println!("Address           Perms Offset  Dev   Inode   Path");
     for line in contents.lines() {
         println!("{}", line);
     }

--- a/src/uu/pmap/src/pmap.rs
+++ b/src/uu/pmap/src/pmap.rs
@@ -28,7 +28,8 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     }
 
     match parse_maps(pid) {
-        Ok(_) => println!("Memory map displayed successfully."),
+        // TODO calculate total
+        Ok(_) => println!(" total"),
         Err(_) => {
             process::exit(1);
         }
@@ -55,7 +56,11 @@ fn parse_maps(pid: &str) -> Result<(), Error> {
     let contents = fs::read_to_string(path)?;
 
     for line in contents.lines() {
-        println!("{}", line);
+        let (memory_range, rest) = line.split_once(' ').expect("line should contain ' '");
+        let (start, _) = memory_range
+            .split_once('-')
+            .expect("memory range should contain '-'");
+        println!("{start:0>16} {rest}");
     }
 
     Ok(())

--- a/src/uu/pmap/src/pmap.rs
+++ b/src/uu/pmap/src/pmap.rs
@@ -20,7 +20,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     match parse_cmdline(pid) {
         Ok(cmdline) => {
-            println!("{}: {}", pid, cmdline);
+            println!("{}:   {}", pid, cmdline);
         }
         Err(_) => {
             process::exit(42);

--- a/tests/by-util/test_pmap.rs
+++ b/tests/by-util/test_pmap.rs
@@ -24,9 +24,16 @@ fn test_existing_pid() {
         .succeeds()
         .stdout_move_str();
 
-    let (first_line, _rest) = result.split_once('\n').unwrap();
+    let (first_line, rest) = result.split_once('\n').unwrap();
     let re = Regex::new(&format!("^{pid}:   .+$")).unwrap();
     assert!(re.is_match(first_line));
+
+    let rest = rest.trim_end();
+    let (memory_map, last_line) = rest.rsplit_once('\n').unwrap();
+    let re = Regex::new("(?m)^[0-9a-f]{16} ").unwrap();
+    assert!(re.is_match(memory_map));
+    // TODO ensure that "total" is followed by a total amount
+    assert!(last_line.starts_with(" total"));
 }
 
 #[test]

--- a/tests/by-util/test_pmap.rs
+++ b/tests/by-util/test_pmap.rs
@@ -15,9 +15,18 @@ fn test_no_args() {
 fn test_existing_pid() {
     use std::process;
 
+    use regex::Regex;
+
     let pid = process::id();
     // TODO ensure that the output format is correct, which is not the case currently
-    new_ucmd!().arg(pid.to_string()).succeeds();
+    let result = new_ucmd!()
+        .arg(pid.to_string())
+        .succeeds()
+        .stdout_move_str();
+
+    let (first_line, _rest) = result.split_once('\n').unwrap();
+    let re = Regex::new(&format!("^{pid}:   .+$")).unwrap();
+    assert!(re.is_match(first_line));
 }
 
 #[test]


### PR DESCRIPTION
This PR fixes the output of the address column when running `cargo run pmap <some PID>` and shows the start address only.

Before the change:
```
...
7addfaf2d000-7addfaf2f000 rw-p 00036000 08:08 10773308                   /usr/lib/ld-linux-x86-64.so.2
...
```
After the change:
```
...
00007addfaf2d000 rw-p 00036000 08:08 10773308                   /usr/lib/ld-linux-x86-64.so.2
...
```
In comparison, the output of the original `pmap`:
```
...
00007addfaf2d000      8K rw--- ld-linux-x86-64.so.2
...
```
The PR also removes an unnecessary header and adds two additional spaces to the output of the first line.