### PR TITLE
pmap: fix perms column & remove unnecessary columns

### DIFF
--- a/src/uu/pmap/src/pmap.rs
+++ b/src/uu/pmap/src/pmap.rs
@@ -62,7 +62,9 @@ fn parse_maps(pid: &str) -> Result<(), Error> {
         let (perms, rest) = rest.split_once(' ').expect("line should contain 2nd ' '");
         let perms = parse_perms(perms);
 
-        println!("{start_address} {size_in_kb:>6}K {perms} {rest}");
+        let cmd: String = rest.split_whitespace().skip(3).collect();
+
+        println!("{start_address} {size_in_kb:>6}K {perms} {cmd}");
     }
 
     Ok(())

--- a/tests/by-util/test_pmap.rs
+++ b/tests/by-util/test_pmap.rs
@@ -30,7 +30,7 @@ fn test_existing_pid() {
 
     let rest = rest.trim_end();
     let (memory_map, last_line) = rest.rsplit_once('\n').unwrap();
-    let re = Regex::new("(?m)^[0-9a-f]{16} +[1-9][0-9]*K ").unwrap();
+    let re = Regex::new("(?m)^[0-9a-f]{16} +[1-9][0-9]*K (-|r)(-|w)(-|x)(-|s)- ").unwrap();
     assert!(re.is_match(memory_map));
     // TODO ensure that "total" is followed by a total amount
     assert!(last_line.starts_with(" total"));


### PR DESCRIPTION
This PR fixes the "perms" column and removes unnecessary columns from the output when running `cargo run pmap <some PID>`.

Before the changes:
```
0000735e54227000      8K rw-p 00036000 08:08 10773308                   /usr/lib/ld-linux-x86-64.so.2
```
After the changes:
```
0000735e54227000      8K rw--- /usr/lib/ld-linux-x86-64.so.2
```
In comparison, the output of the original `pmap`:
```
0000735e54227000      8K rw--- ld-linux-x86-64.so.2
```