### PR TITLE
pmap: trim cmdline

### DIFF
--- a/src/uu/pmap/src/pmap.rs
+++ b/src/uu/pmap/src/pmap.rs
@@ -48,7 +48,8 @@ fn parse_cmdline(pid: &str) -> Result<String, Error> {
         .filter_map(|c| std::str::from_utf8(c).ok())
         .collect::<Vec<&str>>()
         .join(" ");
-    Ok(cmdline)
+    let cmdline = cmdline.trim_end();
+    Ok(cmdline.into())
 }
 
 fn parse_maps(pid: &str) -> Result<(), Error> {

--- a/tests/by-util/test_pmap.rs
+++ b/tests/by-util/test_pmap.rs
@@ -25,7 +25,7 @@ fn test_existing_pid() {
         .stdout_move_str();
 
     let (first_line, rest) = result.split_once('\n').unwrap();
-    let re = Regex::new(&format!("^{pid}:   .+$")).unwrap();
+    let re = Regex::new(&format!("^{pid}:   .+[^ ]$")).unwrap();
     assert!(re.is_match(first_line));
 
     let rest = rest.trim_end();


### PR DESCRIPTION
This PR trims the return value of the `parse_cmdline` function.

Before the change, there is a space at the end of the output:
```
$ cargo run -q pmap 1 | tr " " "."
1:.../sbin/init.\vmlinuz-linux.
```
After the change:
```
$ cargo run -q pmap 1 | tr " " "."
1:.../sbin/init.\vmlinuz-linux
```