### PR TITLE
watch: use array instead of closure

### DIFF
--- a/src/uu/watch/src/watch.rs
+++ b/src/uu/watch/src/watch.rs
@@ -17,7 +17,7 @@ const USAGE: &str = help_usage!("watch.md");
 
 fn parse_interval(input: &str) -> Result<Duration, ParseIntError> {
     // Find index where to split string into seconds and nanos
-    let index = match input.find(|c: char| c == ',' || c == '.') {
+    let index = match input.find([',', '.']) {
         Some(index) => index,
         None => {
             let seconds: u64 = input.parse()?;


### PR DESCRIPTION
This PR fixes a warning from the [manual_pattern_char_comparison](https://rust-lang.github.io/rust-clippy/master/index.html#/manual_pattern_char_comparison) lint introduced with Rust 1.81.