### PR TITLE
free: use no empty line as delimiter with `--line`

### DIFF
--- a/tests/by-util/test_free.rs
+++ b/tests/by-util/test_free.rs
@@ -102,6 +102,23 @@ fn test_count() {
 }
 
 #[test]
+fn test_count_line() {
+    let re = Regex::new(r"^SwapUse +\d+ CachUse +\d+ {2}MemUse +\d+ MemFree +\d+$").unwrap();
+
+    let output = new_ucmd!()
+        .args(&["--count", "2", "--line", "-s", "0.00001"])
+        .succeeds()
+        .stdout_move_str();
+
+    let lines: Vec<&str> = output.lines().collect();
+
+    assert_eq!(2, lines.len());
+
+    assert!(re.is_match(lines[0]));
+    assert!(re.is_match(lines[1]));
+}
+
+#[test]
 fn test_count_zero() {
     new_ucmd!()
         .arg("--count=0")


### PR DESCRIPTION
When using something like `free --line -s1` or `free --line -c2`, the original `free` doesn't output an empty line between the entries whereas our implementation does. This PR removes this empty line from our output. It also does some refactorings to get rid of the variables `count_flag` and `seconds_flag` which are misleading as they don't represent boolean values.