### PR TITLE
build.rs: remove coreutils stuff

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -11,13 +11,13 @@ use std::io::Write;
 use std::path::Path;
 
 pub fn main() {
-    if let Ok(profile) = env::var("PROFILE") {
-        println!("cargo:rustc-cfg=build={profile:?}");
-    }
-
     const ENV_FEATURE_PREFIX: &str = "CARGO_FEATURE_";
     const FEATURE_PREFIX: &str = "feat_";
     const OVERRIDE_PREFIX: &str = "uu_";
+
+    if let Ok(profile) = env::var("PROFILE") {
+        println!("cargo:rustc-cfg=build={profile:?}");
+    }
 
     let out_dir = env::var("OUT_DIR").unwrap();
 

--- a/build.rs
+++ b/build.rs
@@ -13,7 +13,6 @@ use std::path::Path;
 pub fn main() {
     const ENV_FEATURE_PREFIX: &str = "CARGO_FEATURE_";
     const FEATURE_PREFIX: &str = "feat_";
-    const OVERRIDE_PREFIX: &str = "uu_";
 
     if let Ok(profile) = env::var("PROFILE") {
         println!("cargo:rustc-cfg=build={profile:?}");
@@ -54,45 +53,7 @@ pub fn main() {
     let mut phf_map = phf_codegen::OrderedMap::<&str>::new();
     for krate in &crates {
         let map_value = format!("({krate}::uumain, {krate}::uu_app)");
-        match krate.as_ref() {
-            // 'test' is named uu_test to avoid collision with rust core crate 'test'.
-            // It can also be invoked by name '[' for the '[ expr ] syntax'.
-            "uu_test" => {
-                phf_map.entry("test", &map_value);
-                phf_map.entry("[", &map_value);
-            }
-            k if k.starts_with(OVERRIDE_PREFIX) => {
-                phf_map.entry(&k[OVERRIDE_PREFIX.len()..], &map_value);
-            }
-            "false" | "true" => {
-                phf_map.entry(krate, &format!("(r#{krate}::uumain, r#{krate}::uu_app)"));
-            }
-            "hashsum" => {
-                phf_map.entry(krate, &format!("({krate}::uumain, {krate}::uu_app_custom)"));
-
-                let map_value = format!("({krate}::uumain, {krate}::uu_app_common)");
-                let map_value_bits = format!("({krate}::uumain, {krate}::uu_app_bits)");
-                let map_value_b3sum = format!("({krate}::uumain, {krate}::uu_app_b3sum)");
-                phf_map.entry("md5sum", &map_value);
-                phf_map.entry("sha1sum", &map_value);
-                phf_map.entry("sha224sum", &map_value);
-                phf_map.entry("sha256sum", &map_value);
-                phf_map.entry("sha384sum", &map_value);
-                phf_map.entry("sha512sum", &map_value);
-                phf_map.entry("sha3sum", &map_value_bits);
-                phf_map.entry("sha3-224sum", &map_value);
-                phf_map.entry("sha3-256sum", &map_value);
-                phf_map.entry("sha3-384sum", &map_value);
-                phf_map.entry("sha3-512sum", &map_value);
-                phf_map.entry("shake128sum", &map_value_bits);
-                phf_map.entry("shake256sum", &map_value_bits);
-                phf_map.entry("b2sum", &map_value);
-                phf_map.entry("b3sum", &map_value_b3sum);
-            }
-            _ => {
-                phf_map.entry(krate, &map_value);
-            }
-        }
+        phf_map.entry(krate, &map_value);
     }
     write!(mf, "{}", phf_map.build()).unwrap();
     mf.write_all(b"\n}\n").unwrap();


### PR DESCRIPTION
This PR removes some coreutils-related stuff from `build.rs`. And it fixes warnings from the (pedantic) [items_after_statements](https://rust-lang.github.io/rust-clippy/master/index.html#/items_after_statements) lint.