### PR TITLE
readme: add `hugetop` & `sysctl` to todo list

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,10 @@ Ongoing:
 * `watch`: Executes a program periodically, showing output fullscreen.
 
 TODO:
+* `hugetop`: Report hugepage usage of processes and the system as a whole.
 * `pkill`: Kills processes based on name and other attributes.
 * `skill`: Sends a signal to processes based on criteria like user, terminal, etc.
+* `sysctl`: Read or write kernel parameters at run-time.
 * `tload`: Prints a graphical representation of system load average to the terminal.
 * `vmstat`: Reports information about processes, memory, paging, block IO, traps, and CPU activity.
 


### PR DESCRIPTION
I noticed that procps-ng contains two utilities we don't mention in our readme: `hugetop` (a new utility that will come with the next release) and `sysctl`. And so this PR adds them to our todo list.