### PR TITLE
ci: use `--all` when running `cargo test`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - run: cargo test
+      - run: cargo test --all
 
   fmt:
     name: cargo fmt --all -- --check


### PR DESCRIPTION
I noticed that not all tests are run in the CI. This PR adds `--all` when running `cargo test`.

Currently, it should fail with two "mismatched types" errors, which I fixed in #242 