### PR TITLE
pmap: implement `--device`

### DIFF
--- a/tests/by-util/test_pmap.rs
+++ b/tests/by-util/test_pmap.rs
@@ -74,6 +74,22 @@ fn test_non_existing_pid() {
 }
 
 #[test]
+#[cfg(target_os = "linux")]
+fn test_device() {
+    let pid = process::id();
+
+    for arg in ["-d", "--device"] {
+        let result = new_ucmd!()
+            .arg(arg)
+            .arg(pid.to_string())
+            .succeeds()
+            .stdout_move_str();
+
+        assert_device_format(pid, &result);
+    }
+}
+
+#[test]
 fn test_invalid_arg() {
     new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
 }
@@ -94,9 +110,46 @@ fn assert_format(pid: u32, s: &str) {
 
     let rest = rest.trim_end();
     let (memory_map, last_line) = rest.rsplit_once('\n').unwrap();
-    let re = Regex::new("(?m)^[0-9a-f]{16} +[1-9][0-9]*K (-|r)(-|w)(-|x)(-|s)- (  $$[ (anon|stack) $$]|[a-zA-Z0-9._-]+)$").unwrap();
+    let re = Regex::new(r"(?m)^[0-9a-f]{16} +[1-9][0-9]*K (-|r)(-|w)(-|x)(-|s)- (  \[ (anon|stack) \]|[a-zA-Z0-9._-]+)$").unwrap();
     assert!(re.is_match(memory_map));
 
     let re = Regex::new("^ total +[1-9][0-9]*K$").unwrap();
     assert!(re.is_match(last_line));
+}
+
+// Ensure `s` has the following device format (--device):
+//
+// 1234:   /some/path
+// Address           Kbytes Mode  Offset           Device    Mapping
+// 000073eb5f4c7000       8 rw--- 0000000000036000 008:00008 ld-linux-x86-64.so.2
+// 00007ffd588fc000     132 rw--- 0000000000000000 000:00000   [ stack ]
+// ffffffffff600000       4 --x-- 0000000000000000 000:00000   [ anon ]
+// ...
+// mapped: 3060K    writeable/private: 348K    shared: 0K
+#[cfg(target_os = "linux")]
+fn assert_device_format(pid: u32, s: &str) {
+    let lines: Vec<_> = s.lines().collect();
+    let line_count = lines.len();
+
+    let re = Regex::new(&format!("^{pid}:   .+[^ ]$")).unwrap();
+    assert!(re.is_match(lines[0]));
+
+    let expected_header = "Address           Kbytes Mode  Offset           Device    Mapping";
+    assert_eq!(expected_header, lines[1]);
+
+    let re = Regex::new(
+        r"^[0-9a-f]{16} +[1-9][0-9]* (-|r)(-|w)(-|x)(-|s)- [0-9a-f]{16} [0-9a-f]{3}:[0-9a-f]{5} (  \[ (anon|stack) \]|[a-zA-Z0-9._-]+)$",
+    )
+    .unwrap();
+
+    for line in lines.iter().take(line_count - 1).skip(2) {
+        assert!(re.is_match(line), "failing line: {line}");
+    }
+
+    let re = Regex::new(r"^mapped: \d+K\s{4}writeable/private: \d+K\s{4}shared: \d+K$").unwrap();
+    assert!(
+        re.is_match(lines[line_count - 1]),
+        "failing line: {}",
+        lines[line_count - 1]
+    );
 }


### PR DESCRIPTION
This PR implements `-d`/`--device` and creates output in the following format:
```
13176:   ../hello_world/target/debug/hello_world
Address           Kbytes Mode  Offset           Device    Mapping
000060ab2984a000      24 r---- 0000000000000000 008:00008 hello_world
000060ab29850000     248 r-x-- 0000000000006000 008:00008 hello_world
...
ffffffffff600000       4 --x-- 0000000000000000 000:00000   [ anon ]
mapped: 3060K    writeable/private: 348K    shared: 0K
```