### PR TITLE
free: add unit to zero in human mode

### DIFF
--- a/src/uu/free/src/free.rs
+++ b/src/uu/free/src/free.rs
@@ -466,7 +466,9 @@ fn humanized(kib: u64, si: bool) -> String {
 
     let unit_string = {
         let mut tmp = String::from(split[1]);
-        tmp.pop();
+        if tmp != "B" {
+            tmp.pop();
+        }
         tmp
     };
     format!("{}{}", num_string, unit_string)
@@ -526,5 +528,11 @@ mod test {
                 eprintln!("free: failed to read memory info: {}", e);
             }
         }
+    }
+
+    #[test]
+    fn test_humanized_unit_for_zero() {
+        assert_eq!("0B", humanized(0, false));
+        assert_eq!("0B", humanized(0, true));
     }
 }

--- a/src/uu/free/src/free.rs
+++ b/src/uu/free/src/free.rs
@@ -501,25 +501,30 @@ fn detect_unit(arg: &ArgMatches) -> fn(u64) -> u64 {
     }
 }
 
-#[test]
-fn test_line_wide() {
-    let matches_with_line = uu_app()
-        .try_get_matches_from(vec!["free", "--line"])
-        .unwrap();
-    let matches_with_line_wide = uu_app()
-        .try_get_matches_from(vec!["free", "--line", "--wide"])
-        .unwrap();
-    let construct_line_str = parse_output_format(&matches_with_line);
-    let construct_line_wide_str = parse_output_format(&matches_with_line_wide);
-    match parse_meminfo() {
-        Ok(mem_info) => {
-            assert_eq!(
-                construct_line_str(&mem_info),
-                construct_line_wide_str(&mem_info)
-            );
-        }
-        Err(e) => {
-            eprintln!("free: failed to read memory info: {}", e);
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_line_wide() {
+        let matches_with_line = uu_app()
+            .try_get_matches_from(vec!["free", "--line"])
+            .unwrap();
+        let matches_with_line_wide = uu_app()
+            .try_get_matches_from(vec!["free", "--line", "--wide"])
+            .unwrap();
+        let construct_line_str = parse_output_format(&matches_with_line);
+        let construct_line_wide_str = parse_output_format(&matches_with_line_wide);
+        match parse_meminfo() {
+            Ok(mem_info) => {
+                assert_eq!(
+                    construct_line_str(&mem_info),
+                    construct_line_wide_str(&mem_info)
+                );
+            }
+            Err(e) => {
+                eprintln!("free: failed to read memory info: {}", e);
+            }
         }
     }
 }


### PR DESCRIPTION
When using `--human`, values that are zero are currently shown without a unit in our implementation whereas the original `free` displays such values as `0B`. This PR adds the missing unit to such values.