### PR TITLE
pmap: remove `expect()`s from parser & return `Result`

### DIFF
--- a/src/uu/pmap/src/pmap.rs
+++ b/src/uu/pmap/src/pmap.rs
@@ -80,7 +80,7 @@ fn parse_maps(pid: &str) -> Result<u64, Error> {
     let mut total = 0;
 
     for line in contents.lines() {
-        let map_line = parse_map_line(line);
+        let map_line = parse_map_line(line)?;
         println!(
             "{} {:>6}K {} {}",
             map_line.address, map_line.size_in_kb, map_line.perms, map_line.mapping


### PR DESCRIPTION
This PR removes all `expect()`s from the parser, based on the feedback on https://github.com/uutils/procps/pull/249 . I put the changes in its own PR to keep #249 focused on the "device" format.