### PR TITLE
pgrep, w: make tests linux-only

### DIFF
--- a/src/uu/pgrep/src/process.rs
+++ b/src/uu/pgrep/src/process.rs
@@ -381,6 +381,7 @@ pub fn walk_process() -> impl Iterator<Item = ProcessInformation> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(target_os = "linux")]
     use std::{collections::HashSet, str::FromStr};
 
     #[test]
@@ -398,6 +399,7 @@ mod tests {
         assert!(RunState::try_from("Rg").is_err());
     }
 
+    #[cfg(target_os = "linux")]
     fn current_pid() -> usize {
         // Direct read link of /proc/self.
         // It's result must be current programs pid.
@@ -410,6 +412,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(target_os = "linux")]
     fn test_walk_pid() {
         let current_pid = current_pid();
 
@@ -419,6 +422,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(target_os = "linux")]
     fn test_pid_entry() {
         let current_pid = current_pid();
 

--- a/src/uu/w/src/w.rs
+++ b/src/uu/w/src/w.rs
@@ -257,6 +257,7 @@ pub fn uu_app() -> Command {
 }
 
 #[cfg(test)]
+#[cfg(target_os = "linux")]
 mod tests {
     use crate::{
         fetch_cmdline, fetch_pcpu_time, fetch_terminal_number, format_time, get_clock_tick,
@@ -264,7 +265,6 @@ mod tests {
     use std::{fs, path::Path, process};
 
     #[test]
-    #[cfg(target_os = "linux")]
     fn test_format_time() {
         let unix_epoc = chrono::Local::now()
             .format("%Y-%m-%d %H:%M:%S%.6f %::z")
@@ -284,7 +284,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(target_os = "linux")]
     // Get PID of current process and use that for cmdline testing
     fn test_fetch_cmdline() {
         // uucore's utmpx returns an i32, so we cast to that to mimic it.
@@ -297,7 +296,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(target_os = "linux")]
     fn test_fetch_terminal_number() {
         let pid = process::id() as i32;
         let path = Path::new("/proc").join(pid.to_string()).join("stat");
@@ -308,7 +306,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(target_os = "linux")]
     fn test_fetch_pcpu_time() {
         let pid = process::id() as i32;
         let path = Path::new("/proc").join(pid.to_string()).join("stat");


### PR DESCRIPTION
This PR fixes the "unresolved imports" errors on macOS (see https://github.com/uutils/procps/actions/runs/11645635703/job/32438719489?pr=261#step:4:244) by making the `w` test module linux-only. It also makes two `pgrep` tests linux-only because they access `/proc` which is not available on macOS.