### PR TITLE
tests: fix "elided lifetime has a name" warnings

### DIFF
--- a/tests/common/util.rs
+++ b/tests/common/util.rs
@@ -171,7 +171,7 @@ impl CmdResult {
 
     /// Assert `stdout` as bytes with a predicate function returning a `bool`.
     #[track_caller]
-    pub fn stdout_check<'a, F>(&'a self, predicate: F) -> &Self
+    pub fn stdout_check<'a, F>(&'a self, predicate: F) -> &'a Self
     where
         F: Fn(&'a [u8]) -> bool,
     {
@@ -186,7 +186,7 @@ impl CmdResult {
 
     /// Assert `stdout` as `&str` with a predicate function returning a `bool`.
     #[track_caller]
-    pub fn stdout_str_check<'a, F>(&'a self, predicate: F) -> &Self
+    pub fn stdout_str_check<'a, F>(&'a self, predicate: F) -> &'a Self
     where
         F: Fn(&'a str) -> bool,
     {
@@ -201,7 +201,7 @@ impl CmdResult {
 
     /// Assert `stderr` as bytes with a predicate function returning a `bool`.
     #[track_caller]
-    pub fn stderr_check<'a, F>(&'a self, predicate: F) -> &Self
+    pub fn stderr_check<'a, F>(&'a self, predicate: F) -> &'a Self
     where
         F: Fn(&'a [u8]) -> bool,
     {
@@ -216,7 +216,7 @@ impl CmdResult {
 
     /// Assert `stderr` as `&str` with a predicate function returning a `bool`.
     #[track_caller]
-    pub fn stderr_str_check<'a, F>(&'a self, predicate: F) -> &Self
+    pub fn stderr_str_check<'a, F>(&'a self, predicate: F) -> &'a Self
     where
         F: Fn(&'a str) -> bool,
     {


### PR DESCRIPTION
This PR fixes "elided lifetime has a name" warnings that show up in the code coverage jobs (see https://github.com/uutils/procps/actions/runs/11792526702/job/32846334017?pr=263#step:5:251)

https://github.com/uutils/procps/pull/263 must be merged before this PR.