### PR TITLE
top: implement SUMMARY display

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - if: ${{ contains(matrix.os, 'ubuntu') }}
+        run: |
+          sudo apt-get update -y
+          sudo apt-get -yq --no-install-suggests --no-install-recommends install libsystemd-dev
       - run: cargo check
 
   test:
@@ -26,6 +30,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - if: ${{ contains(matrix.os, 'ubuntu') }}
+        run: |
+          sudo apt-get update -y
+          sudo apt-get -yq --no-install-suggests --no-install-recommends install libsystemd-dev
       - run: cargo test --all
 
   fmt:
@@ -71,6 +79,10 @@ jobs:
       uses: dtolnay/rust-toolchain@nightly
       with:
         components: llvm-tools-preview
+    - if: ${{ contains(matrix.job.os, 'ubuntu') }}
+      run: |
+        sudo apt-get update -y
+        sudo apt-get -yq --no-install-suggests --no-install-recommends install libsystemd-dev
     - name: Test
       run: cargo test --no-fail-fast
       env:

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -81,6 +81,10 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.7
+      - if: ${{ contains(matrix.job.os, 'ubuntu') }}
+        run: |
+          sudo apt-get update -y
+          sudo apt-get -yq --no-install-suggests --no-install-recommends install libsystemd-dev
       - name: Initialize workflow variables
         id: vars
         shell: bash

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,16 +87,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
 
 [[package]]
-name = "build-env"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1522ac6ee801a11bf9ef3f80403f4ede6eb41291fac3dde3de09989679305f25"
-
-[[package]]
 name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytesize"
@@ -443,17 +443,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libsystemd-sys"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed080163caa59cc29b34bce2209b737149a4bac148cd9a8b04e4c12822798119"
-dependencies = [
- "build-env",
- "libc",
- "pkg-config",
-]
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -478,12 +467,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
 name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -493,16 +476,6 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
-]
-
-[[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
 ]
 
 [[package]]
@@ -719,7 +692,7 @@ checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.0",
- "zerocopy",
+ "zerocopy 0.8.14",
 ]
 
 [[package]]
@@ -745,7 +718,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b08f3c9802962f7e1b25113931d94f43ed9725bebc59db9d0c3e9a23b67e15ff"
 dependencies = [
  "getrandom 0.3.1",
- "zerocopy",
+ "zerocopy 0.8.14",
 ]
 
 [[package]]
@@ -944,20 +917,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "systemstat"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "668a4db78b439df482c238f559e4ea869017f9e62ef0a059c8bfcd841a4df544"
-dependencies = [
- "bytesize",
- "lazy_static",
- "libc",
- "nom",
- "time",
- "winapi",
-]
-
-[[package]]
 name = "tempfile"
 version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1108,6 +1067,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
+name = "utmp-classic"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e24c654e19afaa6b8f3877ece5d3bed849c2719c56f6752b18ca7da4fcc6e85a"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "thiserror 1.0.69",
+ "time",
+ "utmp-classic-raw",
+ "zerocopy 0.7.35",
+]
+
+[[package]]
+name = "utmp-classic-raw"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22c226537a3d6e01c440c1926ca0256dbee2d19b2229ede6fc4863a6493dd831"
+dependencies = [
+ "cfg-if",
+ "zerocopy 0.7.35",
+]
+
+[[package]]
 name = "uu_free"
 version = "0.0.1"
 dependencies = [
@@ -1230,13 +1213,12 @@ dependencies = [
  "chrono",
  "clap",
  "libc",
- "libsystemd-sys",
  "nix",
+ "pkg-config",
  "prettytable-rs",
  "sysinfo",
- "systemstat",
  "uucore",
- "windows 0.59.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1273,9 +1255,12 @@ dependencies = [
  "nix",
  "number_prefix",
  "os_display",
+ "thiserror 2.0.12",
  "time",
+ "utmp-classic",
  "uucore_procs",
  "wild",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1752,11 +1737,32 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
 version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a367f292d93d4eab890745e75a778da40909cab4d6ff8173693812f79c4a2468"
 dependencies = [
- "zerocopy-derive",
+ "zerocopy-derive 0.8.14",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,6 +93,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
 
 [[package]]
+name = "build-env"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1522ac6ee801a11bf9ef3f80403f4ede6eb41291fac3dde3de09989679305f25"
+
+[[package]]
 name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -421,6 +427,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "libsystemd-sys"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed080163caa59cc29b34bce2209b737149a4bac148cd9a8b04e4c12822798119"
+dependencies = [
+ "build-env",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -563,6 +580,12 @@ checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
  "siphasher",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "powerfmt"
@@ -1170,11 +1193,13 @@ dependencies = [
  "chrono",
  "clap",
  "libc",
+ "libsystemd-sys",
  "nix",
  "prettytable-rs",
  "sysinfo",
  "systemstat",
  "uucore",
+ "windows 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -445,6 +445,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -454,6 +460,16 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -865,6 +881,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "systemstat"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668a4db78b439df482c238f559e4ea869017f9e62ef0a059c8bfcd841a4df544"
+dependencies = [
+ "bytesize",
+ "lazy_static",
+ "libc",
+ "nom",
+ "time",
+ "winapi",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1136,12 +1166,14 @@ dependencies = [
 name = "uu_top"
 version = "0.0.1"
 dependencies = [
+ "bytesize",
  "chrono",
  "clap",
  "libc",
  "nix",
  "prettytable-rs",
  "sysinfo",
+ "systemstat",
  "uucore",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,8 +62,8 @@ thiserror = "2.0.4"
 uucore = "0.0.30"
 walkdir = "2.5.0"
 windows = { version = "0.60.0" }
+windows-sys = { version = "0.59.0", default-features = false }
 xattr = "1.3.1"
-systemstat = "0.2.4"
 
 [dependencies]
 clap = { workspace = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ uucore = "0.0.29"
 walkdir = "2.5.0"
 windows = { version = "0.59.0" }
 xattr = "1.3.1"
+systemstat = "0.2.4"
 
 [dependencies]
 clap = { workspace = true }

--- a/src/uu/top/Cargo.toml
+++ b/src/uu/top/Cargo.toml
@@ -26,7 +26,7 @@ bytesize = { workspace = true }
 libsystemd-sys = "0.9.3"
 
 [target.'cfg(target_os="windows")'.dependencies]
-windows = { version = "0.59.0", features = ["Win32_System_RemoteDesktop"] }
+windows = { version = "0.59.0", features = ["Win32_System_RemoteDesktop", "Wdk_System_SystemInformation"] }
 
 [lib]
 path = "src/top.rs"

--- a/src/uu/top/Cargo.toml
+++ b/src/uu/top/Cargo.toml
@@ -19,6 +19,8 @@ nix = { workspace = true }
 prettytable-rs = { workspace = true }
 sysinfo = { workspace = true }
 chrono = { workspace = true }
+systemstat = { workspace = true }
+bytesize = { workspace = true }
 
 [lib]
 path = "src/top.rs"

--- a/src/uu/top/Cargo.toml
+++ b/src/uu/top/Cargo.toml
@@ -12,21 +12,22 @@ keywords = ["acl", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
 
 [dependencies]
-uucore = { workspace = true, features = ["utmpx"] }
+uucore = { workspace = true, features = ["utmpx", "uptime"] }
 clap = { workspace = true }
 libc = { workspace = true }
 nix = { workspace = true }
 prettytable-rs = { workspace = true }
 sysinfo = { workspace = true }
 chrono = { workspace = true }
-systemstat = { workspace = true }
 bytesize = { workspace = true }
-
-[target.'cfg(target_os="linux")'.dependencies]
-libsystemd-sys = "0.9.3"
-
 [target.'cfg(target_os="windows")'.dependencies]
-windows = { version = "0.59.0", features = ["Win32_System_RemoteDesktop", "Wdk_System_SystemInformation"] }
+windows-sys = { workspace = true, features = [
+    "Win32_System_RemoteDesktop",
+    "Win32_System_SystemInformation",
+] }
+
+[target.'cfg(target_os="linux")'.build-dependencies]
+pkg-config = "0.3.31"
 
 [lib]
 path = "src/top.rs"

--- a/src/uu/top/Cargo.toml
+++ b/src/uu/top/Cargo.toml
@@ -22,6 +22,12 @@ chrono = { workspace = true }
 systemstat = { workspace = true }
 bytesize = { workspace = true }
 
+[target.'cfg(target_os="linux")'.dependencies]
+libsystemd-sys = "0.9.3"
+
+[target.'cfg(target_os="windows")'.dependencies]
+windows = { version = "0.59.0", features = ["Win32_System_RemoteDesktop"] }
+
 [lib]
 path = "src/top.rs"
 

--- a/src/uu/top/build.rs
+++ b/src/uu/top/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    #[cfg(target_os = "linux")]
+    pkg_config::find_library("libsystemd").unwrap();
+}

--- a/src/uu/top/src/header.rs
+++ b/src/uu/top/src/header.rs
@@ -5,10 +5,9 @@
 
 use crate::picker::{sysinfo, systemstat};
 use bytesize::ByteSize;
-use clap::ArgMatches;
 use systemstat::Platform;
 
-pub(crate) fn header(arg: &ArgMatches) -> String {
+pub(crate) fn header(scale_summary_mem: Option<&String>) -> String {
     format!(
         "top - {time} {uptime}, {user}, {load_average}\n\
         {task}\n\
@@ -20,7 +19,7 @@ pub(crate) fn header(arg: &ArgMatches) -> String {
         load_average = load_average(),
         task = task(),
         cpu = cpu(),
-        memory = memory(arg),
+        memory = memory(scale_summary_mem),
     )
 }
 
@@ -331,9 +330,9 @@ fn cpu() -> String {
     todo()
 }
 
-fn memory(arg: &ArgMatches) -> String {
+fn memory(scale_summary_mem: Option<&String>) -> String {
     let binding = sysinfo().read().unwrap();
-    let (unit, unit_name) = match arg.get_one::<String>("scale-summary-mem") {
+    let (unit, unit_name) = match scale_summary_mem {
         Some(scale) => match scale.as_str() {
             "k" => (bytesize::KIB, "KiB"),
             "m" => (bytesize::MIB, "MiB"),

--- a/src/uu/top/src/header.rs
+++ b/src/uu/top/src/header.rs
@@ -1,0 +1,232 @@
+use crate::picker::{sysinfo, systemstat};
+use bytesize::ByteSize;
+use systemstat::Platform;
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+use {
+    std::sync::{Mutex, OnceLock},
+    systemstat::{CPULoad, DelayedMeasurement},
+};
+
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+static LOAD_AVERAGE: OnceLock<Mutex<DelayedMeasurement<CPULoad>>> = OnceLock::new();
+
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+pub(crate) fn cpu_load() -> CPULoad {
+    match LOAD_AVERAGE.get() {
+        None => {
+            LOAD_AVERAGE.get_or_init(|| {
+                Mutex::new(systemstat().read().unwrap().cpu_load_aggregate().unwrap())
+            });
+            systemstat()
+                .read()
+                .unwrap()
+                .cpu_load_aggregate()
+                .unwrap()
+                .done()
+                .unwrap()
+        }
+        Some(v) => {
+            let mut v = v.lock().unwrap();
+            let load = v.done().unwrap();
+            *v = systemstat().read().unwrap().cpu_load_aggregate().unwrap();
+            load
+        }
+    }
+}
+
+pub(crate) fn header() -> String {
+    format!(
+        "top - {time} {uptime}, {user}, {load_average}\n\
+        {task}\n\
+        {cpu}\n\
+        {memory}\n\
+        {swap}",
+        time = chrono::Local::now().format("%H:%M:%S"),
+        uptime = uptime(),
+        user = user(),
+        load_average = load_average(),
+        task = task(),
+        cpu = cpu(),
+        memory = memory(),
+        swap = swap(),
+    )
+}
+
+fn todo() -> String {
+    "TODO".into()
+}
+
+fn format_memory(memory_b: u64, unit: u64) -> f64 {
+    ByteSize::b(memory_b).0 as f64 / unit as f64
+}
+
+fn uptime() -> String {
+    let binding = systemstat().read().unwrap();
+
+    let up_seconds = binding.uptime().unwrap().as_secs();
+    let up_minutes = (up_seconds % (60 * 60)) / 60;
+    let up_hours = (up_seconds % (24 * 60 * 60)) / (60 * 60);
+    let up_days = up_seconds / (24 * 60 * 60);
+
+    let mut res = String::from("up ");
+
+    if up_days > 0 {
+        res.push_str(&format!(
+            "{} day{}, ",
+            up_days,
+            if up_days > 1 { "s" } else { "" }
+        ));
+    }
+    if up_hours > 0 {
+        res.push_str(&format!("{}:{:0>2}", up_hours, up_minutes));
+    } else {
+        res.push_str(&format!("{} min", up_minutes));
+    }
+
+    res
+}
+
+//TODO: Implement active user count
+fn user() -> String {
+    todo()
+}
+
+#[cfg(not(target_os = "windows"))]
+fn load_average() -> String {
+    let binding = systemstat().read().unwrap();
+
+    let load_average = binding.load_average().unwrap();
+    format!(
+        "load average: {:.2}, {:.2}, {:.2}",
+        load_average.one, load_average.five, load_average.fifteen
+    )
+}
+
+#[cfg(target_os = "windows")]
+fn load_average() -> String{
+    todo()
+}
+
+fn task() -> String {
+    let binding = sysinfo().read().unwrap();
+
+    let process = binding.processes();
+    let mut running_process = 0;
+    let mut sleeping_process = 0;
+    let mut stopped_process = 0;
+    let mut zombie_process = 0;
+
+    for (_, process) in process.iter() {
+        match process.status() {
+            sysinfo::ProcessStatus::Run => running_process += 1,
+            sysinfo::ProcessStatus::Sleep => sleeping_process += 1,
+            sysinfo::ProcessStatus::Stop => stopped_process += 1,
+            sysinfo::ProcessStatus::Zombie => zombie_process += 1,
+            _ => {}
+        };
+    }
+
+    format!(
+        "Tasks: {} total, {} running, {} sleeping, {} stopped, {} zombie",
+        process.len(),
+        running_process,
+        sleeping_process,
+        stopped_process,
+        zombie_process,
+    )
+}
+
+#[cfg(target_os = "linux")]
+fn cpu() -> String {
+    let file = std::fs::File::open(std::path::Path::new("/proc/stat")).unwrap();
+    let content = std::io::read_to_string(file).unwrap();
+    let load = content
+        .lines()
+        .next()
+        .unwrap()
+        .strip_prefix("cpu")
+        .unwrap()
+        .split(' ')
+        .filter(|s| !s.is_empty())
+        .collect::<Vec<_>>();
+    let user = load[0].parse::<f64>().unwrap();
+    let nice = load[1].parse::<f64>().unwrap();
+    let system = load[2].parse::<f64>().unwrap();
+    let idle = load[3].parse::<f64>().unwrap_or_default(); // since 2.5.41
+    let io_wait = load[4].parse::<f64>().unwrap_or_default(); // since 2.5.41
+    let hardware_interrupt = load[5].parse::<f64>().unwrap_or_default(); // since 2.6.0
+    let software_interrupt = load[6].parse::<f64>().unwrap_or_default(); // since 2.6.0
+    let steal_time = load[7].parse::<f64>().unwrap_or_default(); // since 2.6.11
+                                                                 // GNU do not show guest and guest_nice
+    let guest = load[8].parse::<f64>().unwrap_or_default(); // since 2.6.24
+    let guest_nice = load[9].parse::<f64>().unwrap_or_default(); // since 2.6.33
+    let total = user
+        + nice
+        + system
+        + idle
+        + io_wait
+        + hardware_interrupt
+        + software_interrupt
+        + steal_time
+        + guest
+        + guest_nice;
+
+    format!(
+        "%Cpu(s):  {:.1} us, {:.1} sy, {:.1} ni, {:.1} id, {:.1} wa, {:.1} hi, {:.1} si, {:.1} st",
+        user / total * 100.0,
+        system / total * 100.0,
+        nice / total * 100.0,
+        idle / total * 100.0,
+        io_wait / total * 100.0,
+        hardware_interrupt / total * 100.0,
+        software_interrupt / total * 100.0,
+        steal_time / total * 100.0,
+    )
+}
+
+//TODO: Implement io wait, hardware interrupt, software interrupt and steal time
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+fn cpu() -> String {
+    let cpu = cpu_load();
+    format!(
+        "%Cpu(s):  {:.1} us,  {:.1} sy,  {:.1} ni, {:.1} id",
+        cpu.user * 100.0,
+        cpu.system * 100.0,
+        cpu.nice * 100.0,
+        cpu.idle * 100.0
+    )
+}
+
+//TODO: Implement for macos
+#[cfg(target_os = "macos")]
+fn cpu() -> String {
+    todo()
+}
+
+fn memory() -> String {
+    let binding = sysinfo().read().unwrap();
+    //TODO: unit from argument
+    let unit = bytesize::MIB;
+
+    format!(
+        "MiB Mem : {:8.1} total, {:8.1} free, {:8.1} used, {:8.1} buff/cache",
+        format_memory(binding.total_memory(), unit),
+        format_memory(binding.free_memory(), unit),
+        format_memory(binding.used_memory(), unit),
+        format_memory(binding.total_memory() - binding.free_memory(), unit),
+    )
+}
+
+fn swap() -> String {
+    let binding = sysinfo().read().unwrap();
+    //TODO: unit from argument
+    let unit = bytesize::MIB;
+
+    format!(
+        "MiB Swap: {:8.1} total, {:8.1} free, {:8.1} used, {:8.1} avail Mem",
+        format_memory(binding.total_swap(), unit),
+        format_memory(binding.free_swap(), unit),
+        format_memory(binding.used_swap(), unit),
+        format_memory(binding.total_memory() - binding.free_memory(), unit),
+    )
+}

--- a/src/uu/top/src/header.rs
+++ b/src/uu/top/src/header.rs
@@ -1,3 +1,8 @@
+// This file is part of the uutils procps package.
+//
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+
 use crate::picker::{sysinfo, systemstat};
 use bytesize::ByteSize;
 use clap::ArgMatches;

--- a/src/uu/top/src/picker.rs
+++ b/src/uu/top/src/picker.rs
@@ -12,17 +12,11 @@ use std::{
     sync::{OnceLock, RwLock},
 };
 use sysinfo::{Pid, System, Users};
-use systemstat::Platform;
 
 static SYSINFO: OnceLock<RwLock<System>> = OnceLock::new();
-static SYSTEMSTAT: OnceLock<RwLock<systemstat::System>> = OnceLock::new();
 
 pub fn sysinfo() -> &'static RwLock<System> {
     SYSINFO.get_or_init(|| RwLock::new(System::new_all()))
-}
-
-pub fn systemstat() -> &'static RwLock<systemstat::System> {
-    SYSTEMSTAT.get_or_init(|| RwLock::new(systemstat::System::new()))
 }
 
 pub(crate) fn pickers(fields: &[String]) -> Vec<Box<dyn Fn(u32) -> String>> {

--- a/src/uu/top/src/picker.rs
+++ b/src/uu/top/src/picker.rs
@@ -12,11 +12,17 @@ use std::{
     sync::{OnceLock, RwLock},
 };
 use sysinfo::{Pid, System, Users};
+use systemstat::Platform;
 
 static SYSINFO: OnceLock<RwLock<System>> = OnceLock::new();
+static SYSTEMSTAT: OnceLock<RwLock<systemstat::System>> = OnceLock::new();
 
 pub fn sysinfo() -> &'static RwLock<System> {
     SYSINFO.get_or_init(|| RwLock::new(System::new_all()))
+}
+
+pub fn systemstat() -> &'static RwLock<systemstat::System> {
+    SYSTEMSTAT.get_or_init(|| RwLock::new(systemstat::System::new()))
 }
 
 pub(crate) fn pickers(fields: &[String]) -> Vec<Box<dyn Fn(u32) -> String>> {

--- a/src/uu/top/src/top.rs
+++ b/src/uu/top/src/top.rs
@@ -99,7 +99,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         table
     };
 
-    println!("{}", header(&matches));
+    println!("{}", header(matches.get_one::<String>("scale-summary-mem")));
     println!("\n");
 
     let cutter = {

--- a/src/uu/top/src/top.rs
+++ b/src/uu/top/src/top.rs
@@ -55,9 +55,6 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     // Must refresh twice.
     // https://docs.rs/sysinfo/0.31.2/sysinfo/struct.System.html#method.refresh_cpu_usage
     picker::sysinfo().write().unwrap().refresh_all();
-    // Similar to the above.
-    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
-    crate::header::cpu_load();
     sleep(Duration::from_millis(200));
     picker::sysinfo().write().unwrap().refresh_all();
 

--- a/src/uu/top/src/top.rs
+++ b/src/uu/top/src/top.rs
@@ -102,7 +102,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         table
     };
 
-    println!("{}", header());
+    println!("{}", header(&matches));
     println!("\n");
 
     let cutter = {
@@ -261,7 +261,7 @@ pub fn uu_app() -> Command {
             // arg!(-b  --"batch-mode"                         "run in non-interactive batch mode"),
             // arg!(-c  --"cmdline-toggle"                     "reverse last remembered 'c' state"),
             // arg!(-d  --delay                <SECS>          "iterative delay as SECS [.TENTHS]"),
-            // arg!(-E  --"scale-summary-mem"  <SCALE>         "set mem as: k,m,g,t,p,e for SCALE"),
+            arg!(-E  --"scale-summary-mem"  <SCALE>         "set mem as: k,m,g,t,p,e for SCALE"),
             // arg!(-e  --"scale-task-mem"     <SCALE>         "set mem with: k,m,g,t,p for SCALE"),
             // arg!(-H  --"threads-show"                       "show tasks plus all their threads"),
             // arg!(-i  --"idle-toggle"                        "reverse last remembered 'i' state"),

--- a/src/uu/top/src/top.rs
+++ b/src/uu/top/src/top.rs
@@ -4,6 +4,7 @@
 // file that was distributed with this source code.
 
 use clap::{arg, crate_version, value_parser, ArgAction, ArgGroup, ArgMatches, Command};
+use header::header;
 use picker::pickers;
 use picker::sysinfo;
 use prettytable::{format::consts::FORMAT_CLEAN, Row, Table};
@@ -18,6 +19,7 @@ const ABOUT: &str = help_about!("top.md");
 const USAGE: &str = help_usage!("top.md");
 
 mod field;
+mod header;
 mod picker;
 
 #[allow(unused)]
@@ -53,6 +55,9 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     // Must refresh twice.
     // https://docs.rs/sysinfo/0.31.2/sysinfo/struct.System.html#method.refresh_cpu_usage
     picker::sysinfo().write().unwrap().refresh_all();
+    // Similar to the above.
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    crate::header::cpu_load();
     sleep(Duration::from_millis(200));
     picker::sysinfo().write().unwrap().refresh_all();
 
@@ -155,11 +160,6 @@ where
         result.extend(std::iter::repeat(' ').take(width - input.len()));
         result
     }
-}
-
-// TODO: Implement information collecting.
-fn header() -> String {
-    "TODO".into()
 }
 
 // TODO: Implement fields selecting


### PR DESCRIPTION
Resolves #207 

Tasks:
- [x] time and uptime
- [x] active user count
- [ ] cpu load average
- [x] task summary
- [ ] cpu load
- [x] memory and swap summary
- [x] determine memory unit from `--scale-summary-mem`

I add crate `systemstat` for some of the values.

```text
top - 13:03:00 up 1:33, 1 user, load average: 2.01, 1.48, 1.28
Tasks: 1040 total, 6 running, 974 sleeping, 0 stopped, 0 zombie
%Cpu(s):  13.9 us, 3.3 sy, 0.0 ni, 82.4 id, 0.3 wa, 0.0 hi, 0.1 si, 0.0 st
MiB Mem :   7636.4 total,    433.3 free,   6415.1 used,    788.0 buff/cache
MiB Swap:  30518.0 total,  27218.5 free,   3299.5 used,   1221.3 avail Mem
```
