### PR TITLE
Bump `rand` & adapt tests to its API changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -548,7 +548,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
 dependencies = [
  "phf_shared",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -617,7 +617,7 @@ dependencies = [
  "phf",
  "phf_codegen",
  "pretty_assertions",
- "rand",
+ "rand 0.9.0",
  "regex",
  "rlimit",
  "sysinfo",
@@ -656,19 +656,28 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
- "libc",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.0",
+ "zerocopy",
 ]
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.0",
 ]
 
 [[package]]
@@ -676,8 +685,15 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+
+[[package]]
+name = "rand_core"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b08f3c9802962f7e1b25113931d94f43ed9725bebc59db9d0c3e9a23b67e15ff"
 dependencies = [
- "getrandom 0.2.14",
+ "getrandom 0.3.1",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1694,3 +1710,23 @@ name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a367f292d93d4eab890745e75a778da40909cab4d6ff8173693812f79c4a2468"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3931cb58c62c13adec22e38686b559c86a30565e16ad6e8510a337cedc611e1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ nix = { version = "0.29", default-features = false, features = ["process"] }
 phf = "0.11.2"
 phf_codegen = "0.11.2"
 prettytable-rs = "0.10.0"
-rand = { version = "0.8.5", features = ["small_rng"] }
+rand = { version = "0.9.0", features = ["small_rng"] }
 regex = "1.10.4"
 sysinfo = "0.33.0"
 tempfile = "3.10.1"

--- a/tests/common/random.rs
+++ b/tests/common/random.rs
@@ -3,8 +3,8 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
-use rand::distributions::{Distribution, Uniform};
-use rand::{thread_rng, Rng};
+use rand::distr::{Distribution, Uniform};
+use rand::{rng, Rng};
 
 /// Samples alphanumeric characters `[A-Za-z0-9]` including newline `\n`
 ///
@@ -38,7 +38,7 @@ impl AlphanumericNewline {
     where
         R: Rng + ?Sized,
     {
-        let idx = rng.gen_range(0..Self::CHARSET.len());
+        let idx = rng.random_range(0..Self::CHARSET.len());
         Self::CHARSET[idx]
     }
 }
@@ -80,7 +80,7 @@ impl RandomString {
     where
         D: Distribution<u8>,
     {
-        thread_rng()
+        rng()
             .sample_iter(dist)
             .take(length)
             .map(|b| b as char)
@@ -132,15 +132,15 @@ impl RandomString {
             return if num_delimiter > 0 {
                 String::from(delimiter as char)
             } else {
-                String::from(thread_rng().sample(&dist) as char)
+                String::from(rng().sample(&dist) as char)
             };
         }
 
         let samples = length - 1;
-        let mut result: Vec<u8> = thread_rng().sample_iter(&dist).take(samples).collect();
+        let mut result: Vec<u8> = rng().sample_iter(&dist).take(samples).collect();
 
         if num_delimiter == 0 {
-            result.push(thread_rng().sample(&dist));
+            result.push(rng().sample(&dist));
             return String::from_utf8(result).unwrap();
         }
 
@@ -150,9 +150,10 @@ impl RandomString {
             num_delimiter
         };
 
-        let between = Uniform::new(0, samples);
+        // safe to unwrap because samples is at least 1, thus high > low
+        let between = Uniform::new(0, samples).unwrap();
         for _ in 0..num_delimiter {
-            let mut pos = between.sample(&mut thread_rng());
+            let mut pos = between.sample(&mut rng());
             let turn = pos;
             while result[pos] == delimiter {
                 pos += 1;
@@ -169,7 +170,7 @@ impl RandomString {
         if end_with_delimiter {
             result.push(delimiter);
         } else {
-            result.push(thread_rng().sample(&dist));
+            result.push(rng().sample(&dist));
         }
 
         String::from_utf8(result).unwrap()
@@ -179,7 +180,7 @@ impl RandomString {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rand::distributions::Alphanumeric;
+    use rand::distr::Alphanumeric;
 
     #[test]
     fn test_random_string_generate() {


### PR DESCRIPTION
This PR bumps `rand` from `0.8.5` to `0.9.0` and adapts `tests/common/random.rs` to the API changes.