### PR TITLE
Unify matching logic in pgrep and pkill

### DIFF
--- a/src/uu/pgrep/src/pgrep.rs
+++ b/src/uu/pgrep/src/pgrep.rs
@@ -293,8 +293,12 @@ pub fn uu_app() -> Command {
             // arg!(-w     --lightweight           "list all TID"),
             arg!(-c     --count                 "count of matching processes"),
             arg!(-f     --full                  "use full process name to match"),
-            // arg!(-g     --pgroup <PGID>     ... "match listed process group IDs"),
-            // arg!(-G     --group <GID>       ... "match real group IDs"),
+            // arg!(-g     --pgroup <PGID>     ... "match listed process group IDs")
+            //     .value_delimiter(',')
+            //     .value_parser(clap::value_parser!(u64)),
+            // arg!(-G     --group <GID>       ... "match real group IDs")
+            //     .value_delimiter(',')
+            //     .value_parser(clap::value_parser!(u64)),
             arg!(-i     --"ignore-case"         "match case insensitively"),
             arg!(-n     --newest                "select most recently started"),
             arg!(-o     --oldest                "select least recently started"),
@@ -303,17 +307,29 @@ pub fn uu_app() -> Command {
             arg!(-P     --parent <PPID>         "match only child processes of the given parent")
                 .value_delimiter(',')
                 .value_parser(clap::value_parser!(u64)),
-            // arg!(-s     --session <SID>         "match session IDs"),
+            // arg!(-s     --session <SID>         "match session IDs")
+            //     .value_delimiter(',')
+            //     .value_parser(clap::value_parser!(u64)),
+            // arg!(--signal <sig>                 "signal to send (either number or name)"),
             arg!(-t     --terminal <tty>        "match by controlling terminal")
                 .value_delimiter(','),
-            // arg!(-u     --euid <ID>         ... "match by effective IDs"),
-            // arg!(-U     --uid <ID>          ... "match by real IDs"),
+            // arg!(-u     --euid <ID>         ... "match by effective IDs")
+            //     .value_delimiter(',')
+            //     .value_parser(clap::value_parser!(u64)),
+            // arg!(-U     --uid <ID>          ... "match by real IDs")
+            //     .value_delimiter(',')
+            //     .value_parser(clap::value_parser!(u64)),
             arg!(-x     --exact                 "match exactly with the command name"),
             // arg!(-F     --pidfile <file>        "read PIDs from file"),
             // arg!(-L     --logpidfile            "fail if PID file is not locked"),
             arg!(-r     --runstates <state>     "match runstates [D,S,Z,...]"),
+            // arg!(-A     --"ignore-ancestors"    "exclude our ancestors from results"),
+            // arg!(--cgroup <grp>                 "match by cgroup v2 names")
+            //     .value_delimiter(','),
             // arg!(       --ns <PID>              "match the processes that belong to the same namespace as <pid>"),
-            // arg!(       --nslist <ns>       ... "list which namespaces will be considered for the --ns option."),
+            // arg!(       --nslist <ns>       ... "list which namespaces will be considered for the --ns option.")
+            //     .value_delimiter(',')
+            //     .value_parser(["ipc", "mnt", "net", "pid", "user", "uts"]),
         ])
         .arg(
             Arg::new("pattern")

--- a/src/uu/pgrep/src/pgrep.rs
+++ b/src/uu/pgrep/src/pgrep.rs
@@ -170,7 +170,7 @@ fn collect_matched_pids(settings: &Settings) -> Vec<ProcessInformation> {
         let mut tmp_vec = Vec::new();
 
         for mut pid in walk_process().collect::<Vec<_>>() {
-            let run_state_matched = match (&settings.runstates, (pid).run_state()) {
+            let run_state_matched = match (&settings.runstates, pid.run_state()) {
                 (Some(arg_run_states), Ok(pid_state)) => {
                     arg_run_states.contains(&pid_state.to_string())
                 }

--- a/src/uu/pkill/src/pkill.rs
+++ b/src/uu/pkill/src/pkill.rs
@@ -347,16 +347,16 @@ pub fn uu_app() -> Command {
         .args([
             // arg!(-<sig>                    "signal to send (either number or name)"),
             arg!(-H --"require-handler"    "match only if signal handler is present"),
-            arg!(-q --queue <value>        "integer value to be sent with the signal"),
+            // arg!(-q --queue <value>        "integer value to be sent with the signal"),
             arg!(-e --echo                 "display what is killed"),
             arg!(-c --count                "count of matching processes"),
             arg!(-f --full                 "use full process name to match"),
-            arg!(-g --pgroup <PGID>        "match listed process group IDs")
-                .value_delimiter(',')
-                .value_parser(clap::value_parser!(u64)),
-            arg!(-G --group <GID>          "match real group IDs")
-                .value_delimiter(',')
-                .value_parser(clap::value_parser!(u64)),
+            // arg!(-g --pgroup <PGID>        "match listed process group IDs")
+            //     .value_delimiter(',')
+            //     .value_parser(clap::value_parser!(u64)),
+            // arg!(-G --group <GID>          "match real group IDs")
+            //     .value_delimiter(',')
+            //     .value_parser(clap::value_parser!(u64)),
             arg!(-i --"ignore-case"        "match case insensitively"),
             arg!(-n --newest               "select most recently started"),
             arg!(-o --oldest               "select least recently started"),
@@ -365,29 +365,28 @@ pub fn uu_app() -> Command {
             arg!(-P --parent <PPID>        "match only child processes of the given parent")
                 .value_delimiter(',')
                 .value_parser(clap::value_parser!(u64)),
-            arg!(-s --session <SID>        "match session IDs")
-                .value_delimiter(',')
-                .value_parser(clap::value_parser!(u64)),
+            // arg!(-s --session <SID>        "match session IDs")
+            //     .value_delimiter(',')
+            //     .value_parser(clap::value_parser!(u64)),
             arg!(--signal <sig>            "signal to send (either number or name)"),
-            arg!(-t --terminal <tty>       "match by controlling terminal")
-                .value_delimiter(','),
-            arg!(-u --euid <ID>            "match by effective IDs")
-                .value_delimiter(',')
-                .value_parser(clap::value_parser!(u64)),
-            arg!(-U --uid <ID>             "match by real IDs")
-                .value_delimiter(',')
-                .value_parser(clap::value_parser!(u64)),
+            arg!(-t --terminal <tty>       "match by controlling terminal").value_delimiter(','),
+            // arg!(-u --euid <ID>            "match by effective IDs")
+            //     .value_delimiter(',')
+            //     .value_parser(clap::value_parser!(u64)),
+            // arg!(-U --uid <ID>             "match by real IDs")
+            //     .value_delimiter(',')
+            //     .value_parser(clap::value_parser!(u64)),
             arg!(-x --exact                "match exactly with the command name"),
-            arg!(-F --pidfile <file>       "read PIDs from file"),
-            arg!(-L --logpidfile           "fail if PID file is not locked"),
+            // arg!(-F --pidfile <file>       "read PIDs from file"),
+            // arg!(-L --logpidfile           "fail if PID file is not locked"),
             arg!(-r --runstates <state>    "match runstates [D,S,Z,...]"),
-            arg!(-A --"ignore-ancestors"   "exclude our ancestors from results"),
-            arg!(--cgroup <grp>            "match by cgroup v2 names")
-                .value_delimiter(','),
-            arg!(--ns <PID>                "match the processes that belong to the same namespace as <pid>"),
-            arg!(--nslist <ns>             "list which namespaces will be considered for the --ns option.")
-                .value_delimiter(',')
-                .value_parser(["ipc", "mnt", "net", "pid", "user", "uts"]),
+            // arg!(-A --"ignore-ancestors"   "exclude our ancestors from results"),
+            // arg!(--cgroup <grp>            "match by cgroup v2 names")
+            //     .value_delimiter(','),
+            // arg!(--ns <PID>                "match the processes that belong to the same namespace as <pid>"),
+            // arg!(--nslist <ns>             "list which namespaces will be considered for the --ns option.")
+            //     .value_delimiter(',')
+            //     .value_parser(["ipc", "mnt", "net", "pid", "user", "uts"]),
         ])
         .arg(
             Arg::new("pattern")

--- a/src/uu/pkill/src/pkill.rs
+++ b/src/uu/pkill/src/pkill.rs
@@ -305,14 +305,8 @@ fn handle_obsolete(args: &mut [String]) {
 
 #[cfg(unix)]
 fn parse_signal_value(signal_name: &str) -> UResult<usize> {
-    let optional_signal_value = signal_by_name_or_value(signal_name);
-    match optional_signal_value {
-        Some(x) => Ok(x),
-        None => Err(USimpleError::new(
-            1,
-            format!("Unknown signal {}", signal_name.quote()),
-        )),
-    }
+    signal_by_name_or_value(signal_name)
+        .ok_or_else(|| USimpleError::new(1, format!("Unknown signal {}", signal_name.quote())))
 }
 
 #[cfg(unix)]

--- a/src/uu/pkill/src/pkill.rs
+++ b/src/uu/pkill/src/pkill.rs
@@ -36,6 +36,7 @@ struct Settings {
     exact: bool,
     full: bool,
     ignore_case: bool,
+    inverse: bool,
     newest: bool,
     oldest: bool,
     older: Option<u64>,
@@ -64,6 +65,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         exact: matches.get_flag("exact"),
         full: matches.get_flag("full"),
         ignore_case: matches.get_flag("ignore-case"),
+        inverse: matches.get_flag("inverse"),
         newest: matches.get_flag("newest"),
         oldest: matches.get_flag("oldest"),
         parent: matches
@@ -235,11 +237,12 @@ fn collect_matched_pids(settings: &Settings) -> Vec<ProcessInformation> {
                 _ => true,
             };
 
-            if run_state_matched
+            if (run_state_matched
                 && pattern_matched
                 && tty_matched
                 && older_matched
-                && parent_matched
+                && parent_matched)
+                ^ settings.inverse
             {
                 tmp_vec.push(pid);
             }
@@ -343,12 +346,13 @@ pub fn uu_app() -> Command {
         .about(ABOUT)
         .override_usage(format_usage(USAGE))
         .args_override_self(true)
-        .group(ArgGroup::new("oldest_newest").args(["oldest", "newest"]))
+        .group(ArgGroup::new("oldest_newest").args(["oldest", "newest", "inverse"]))
         .args([
             // arg!(-<sig>                    "signal to send (either number or name)"),
             arg!(-H --"require-handler"    "match only if signal handler is present"),
             // arg!(-q --queue <value>        "integer value to be sent with the signal"),
             arg!(-e --echo                 "display what is killed"),
+            arg!(--inverse                 "negates the matching"),
             arg!(-c --count                "count of matching processes"),
             arg!(-f --full                 "use full process name to match"),
             // arg!(-g --pgroup <PGID>        "match listed process group IDs")

--- a/tests/by-util/test_pgrep.rs
+++ b/tests/by-util/test_pgrep.rs
@@ -347,3 +347,24 @@ fn test_parent_non_matching_parent() {
         .code_is(1)
         .no_output();
 }
+
+#[test]
+#[cfg(target_os = "linux")]
+fn test_require_handler() {
+    new_ucmd!()
+        .arg("--require-handler")
+        .arg("--signal=INT")
+        .arg("NONEXISTENT")
+        .fails()
+        .no_output();
+}
+
+#[test]
+#[cfg(target_os = "linux")]
+fn test_invalid_signal() {
+    new_ucmd!()
+        .arg("--signal=foo")
+        .arg("NONEXISTENT")
+        .fails()
+        .stderr_contains("Unknown signal 'foo'");
+}

--- a/tests/by-util/test_pkill.rs
+++ b/tests/by-util/test_pkill.rs
@@ -44,6 +44,17 @@ fn test_invalid_arg() {
     new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
 }
 
+#[cfg(target_os = "linux")]
+#[test]
+fn test_inverse() {
+    new_ucmd!()
+        .arg("-0")
+        .arg("--inverse")
+        .arg("NONEXISTENT")
+        .fails()
+        .stderr_contains("Permission denied");
+}
+
 #[cfg(unix)]
 #[test]
 fn test_help() {


### PR DESCRIPTION
Currently pgrep and pkill implement slightly different set command line args for process matching, even though both commands should support the same features. This PR extends the functionality of both tools to their superset of features. This will allow deduplicating the process matching part into a common module in a future PR.