### PR TITLE
pgrep: don't show msg if pattern is 15 chars long

### DIFF
--- a/src/uu/pgrep/src/process_matcher.rs
+++ b/src/uu/pgrep/src/process_matcher.rs
@@ -78,7 +78,7 @@ pub fn get_match_settings(matches: &ArgMatches) -> UResult<Settings> {
         ));
     }
 
-    if !settings.full && pattern.len() >= 15 {
+    if !settings.full && pattern.len() > 15 {
         let msg = format!("pattern that searches for process name longer than 15 characters will result in zero matches\n\
                            Try `{} -f' option to match against the complete command line.", uucore::util_name());
         return Err(USimpleError::new(1, msg));

--- a/tests/by-util/test_pgrep.rs
+++ b/tests/by-util/test_pgrep.rs
@@ -380,7 +380,13 @@ fn test_does_not_match_pid() {
 #[cfg(target_os = "linux")]
 fn test_too_long_pattern() {
     new_ucmd!()
-        .arg("THIS_IS_OVER_16_CHARS")
+        .arg("A".repeat(15))
+        .fails()
+        .code_is(1)
+        .no_output();
+
+    new_ucmd!()
+        .arg("A".repeat(16))
         .fails()
         .code_is(1)
         .stderr_contains("pattern that searches for process name longer than 15 characters will result in zero matches");


### PR DESCRIPTION
The original `pgrep` shows a message if the pattern is longer than 15 chars:
```
$ pgrep 123456789012345
$ pgrep 1234567890123456
pgrep: pattern that searches for process name longer than 15 characters will result in zero matches
Try `pgrep -f' option to match against the complete command line.
```
We showed this message if the pattern was 15 chars or longer. This PR fixes the issue.