### PR TITLE
Bump `bytesize` and adapt `free` to API change

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,9 +100,9 @@ checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "bytesize"
-version = "1.3.2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d2c12f985c78475a6b8d629afd0c360260ef34cfef52efccdcfd31972f81c2e"
+checksum = "ce3dbc6ab70a821f3e9c36084d4c1a96f50006fd41697123d3fe0a5f03d5912c"
 
 [[package]]
 name = "cc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ feat_common_core = [
 ]
 
 [workspace.dependencies]
-bytesize = "1.3.0"
+bytesize = "2.0.0"
 chrono = { version = "0.4.38", default-features = false, features = ["clock"] }
 clap = { version = "4.5.4", features = ["wrap_help", "cargo"] }
 clap_complete = "4.5.2"

--- a/src/uu/free/src/free.rs
+++ b/src/uu/free/src/free.rs
@@ -458,7 +458,17 @@ fn construct_committed_str(mem_info: &MemInfo, n2s: &dyn Fn(u64) -> String) -> S
 
 // Here's the `-h` `--human` flag processing logic
 fn humanized(kib: u64, si: bool) -> String {
-    let binding = ByteSize::kib(kib).to_string_as(!si);
+    let binding = {
+        let display = ByteSize::kib(kib).display();
+
+        if si {
+            display.si()
+        } else {
+            display.iec()
+        }
+    }
+    .to_string();
+
     let split: Vec<&str> = binding.split(' ').collect();
 
     // TODO: finish the logic of automatic scale.


### PR DESCRIPTION
This PR bumps `bytesize` from `1.3` to `2.0` and adapts `free` to an API change (the function `to_string_as` got removed).