### PR TITLE
process_matcher: Don't match own procps process

### DIFF
--- a/src/uu/pgrep/src/process_matcher.rs
+++ b/src/uu/pgrep/src/process_matcher.rs
@@ -168,7 +168,12 @@ fn collect_matched_pids(settings: &Settings) -> Vec<ProcessInformation> {
     let filtered: Vec<ProcessInformation> = {
         let mut tmp_vec = Vec::new();
 
+        let our_pid = std::process::id() as usize;
         for mut pid in walk_process().collect::<Vec<_>>() {
+            if pid.pid == our_pid {
+                continue;
+            }
+
             let run_state_matched = match (&settings.runstates, pid.run_state()) {
                 (Some(arg_run_states), Ok(pid_state)) => {
                     arg_run_states.contains(&pid_state.to_string())

--- a/tests/by-util/test_pgrep.rs
+++ b/tests/by-util/test_pgrep.rs
@@ -420,3 +420,15 @@ fn test_current_user() {
         .arg(uucore::process::getuid().to_string())
         .succeeds();
 }
+
+#[test]
+#[cfg(target_os = "linux")]
+fn test_does_not_match_current_process() {
+    let our_pid = std::process::id();
+    dbg!(&our_pid);
+    new_ucmd!()
+        .arg("-f")
+        .arg("UNIQUE_STRING_THAT_DOES_NOT_MATCH_ANY_OTHER_PROCESS")
+        .fails()
+        .no_output();
+}


### PR DESCRIPTION
For example, pgrep should never report itself as a match (but it can match other pgrep processes).