### PR TITLE
pgrep: Support -w option

### DIFF
--- a/src/uu/pgrep/src/pgrep.rs
+++ b/src/uu/pgrep/src/pgrep.rs
@@ -28,7 +28,8 @@ const USAGE: &str = help_usage!("pgrep.md");
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let matches = uu_app().try_get_matches_from(args)?;
-    let settings = process_matcher::get_match_settings(&matches)?;
+    let mut settings = process_matcher::get_match_settings(&matches)?;
+    settings.threads = matches.get_flag("lightweight");
 
     // Collect pids
     let pids = process_matcher::find_matching_pids(&settings);
@@ -82,7 +83,7 @@ pub fn uu_app() -> Command {
                 .hide_default_value(true),
             arg!(-l     --"list-name"           "list PID and process name"),
             arg!(-a     --"list-full"           "list PID and full command line"),
-            // arg!(-w     --lightweight           "list all TID"),
+            arg!(-w     --lightweight           "list all TID"),
         ])
         .args(process_matcher::clap_args(
             "Name of the program to find the PID of",

--- a/tests/by-util/test_pgrep.rs
+++ b/tests/by-util/test_pgrep.rs
@@ -478,3 +478,21 @@ fn test_session() {
 fn test_nonexisting_session() {
     new_ucmd!().arg("--session=9999999999").fails();
 }
+
+#[test]
+#[cfg(target_os = "linux")]
+fn test_threads() {
+    std::thread::Builder::new()
+        .name("PgrepTest".to_owned())
+        .spawn(|| {
+            let thread_tid = unsafe { uucore::libc::gettid() };
+            new_ucmd!()
+                .arg("-w")
+                .arg("PgrepTest")
+                .succeeds()
+                .stdout_contains(thread_tid.to_string());
+        })
+        .unwrap()
+        .join()
+        .unwrap();
+}


### PR DESCRIPTION
Unlike pidof's similar option, the pgrep version will run the match predicates against every thread of the system and printing matching tids (unlike pidof which will run match predicates on every process of the system and then list every thread of every matched process).