### PR TITLE
pidof: disable "test_find_init", as it fails in CI

### DIFF
--- a/tests/by-util/test_pidof.rs
+++ b/tests/by-util/test_pidof.rs
@@ -12,6 +12,7 @@ fn test_invalid_arg() {
 
 #[test]
 #[cfg(target_os = "linux")]
+#[ignore = "fails in CI"]
 fn test_find_init() {
     new_ucmd!().arg("init").succeeds();
 }


### PR DESCRIPTION
This PR disables `test_find_init` as it recently started to fail in the CI (see https://github.com/uutils/procps/pull/355, https://github.com/uutils/procps/pull/356 and https://github.com/uutils/procps/pull/357) whereas it works locally. 