### PR TITLE
pidof: don't require program name

### DIFF
--- a/src/uu/pidof/src/pidof.rs
+++ b/src/uu/pidof/src/pidof.rs
@@ -117,7 +117,6 @@ pub fn uu_app() -> Command {
         .arg(
             Arg::new("program-name")
                 .help("Program name.")
-                .required(true)
                 .index(1)
                 .action(ArgAction::Append),
         )

--- a/tests/by-util/test_pidof.rs
+++ b/tests/by-util/test_pidof.rs
@@ -6,6 +6,11 @@
 use crate::common::util::TestScenario;
 
 #[test]
+fn test_no_args() {
+    new_ucmd!().fails().code_is(1).no_output();
+}
+
+#[test]
 fn test_invalid_arg() {
     new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
 }
@@ -21,12 +26,6 @@ fn test_find_init() {
 #[cfg(target_os = "linux")]
 fn test_find_kthreadd() {
     new_ucmd!().arg("kthreadd").succeeds();
-}
-
-#[test]
-#[cfg(target_os = "linux")]
-fn test_no_program() {
-    new_ucmd!().fails().code_is(1).no_output();
 }
 
 #[test]

--- a/tests/by-util/test_pidof.rs
+++ b/tests/by-util/test_pidof.rs
@@ -26,7 +26,7 @@ fn test_find_kthreadd() {
 #[test]
 #[cfg(target_os = "linux")]
 fn test_no_program() {
-    new_ucmd!().fails().code_is(1);
+    new_ucmd!().fails().code_is(1).no_output();
 }
 
 #[test]


### PR DESCRIPTION
Currently, we require at least one program name and if none is provided, a clap error message is shown. This makes the following code snippet in `uumain` unreachable:
```rust
    if arg_program_name.is_none() {
        uucore::error::set_exit_code(1);
        return Ok(());
    };
```
This PR no longer requires a program name and thus makes the snippet above reachable. It also corresponds with the behavior of the original `pidof`, which doesn't show an error message if called without any args.

The PR also removes the `#[cfg(target_os = "linux")]` of the test as it is not necessary.