### PR TITLE
w: implement idle_time and elapsed time formatting

### DIFF
--- a/src/uu/w/src/w.rs
+++ b/src/uu/w/src/w.rs
@@ -3,20 +3,16 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
+use std::time::Duration;
+
 #[cfg(target_os = "linux")]
 use chrono::Datelike;
 use clap::crate_version;
 use clap::{Arg, ArgAction, Command};
 #[cfg(target_os = "linux")]
 use libc::{sysconf, _SC_CLK_TCK};
-use std::process;
 #[cfg(target_os = "linux")]
-use std::{
-    collections::HashMap,
-    fs,
-    path::Path,
-    time::{Duration, SystemTime},
-};
+use std::{collections::HashMap, fs, path::Path, process, time::SystemTime};
 #[cfg(target_os = "linux")]
 use uucore::utmpx::Utmpx;
 use uucore::{error::UResult, format_usage, help_about, help_usage};
@@ -99,7 +95,11 @@ fn fetch_idle_time(tty: String) -> Result<Duration, std::io::Error> {
     }
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(not(target_os = "linux"))]
+fn fetch_idle_time(tty: String) -> Result<Duration, std::io::Error> {
+    Ok(Duration::ZERO)
+}
+
 fn format_time_elapsed(
     time: Duration,
     old_style: bool,
@@ -121,16 +121,14 @@ fn format_time_elapsed(
             t.num_seconds() % 60,
             if old_style { "m" } else { "" }
         ))
+    } else if old_style {
+        Ok(String::new())
     } else {
-        if old_style {
-            Ok(format!(""))
-        } else {
-            Ok(format!(
-                "{}.{:02}s",
-                t.num_seconds() % 60,
-                (t.num_milliseconds() % 1000) / 10
-            ))
-        }
+        Ok(format!(
+            "{}.{:02}s",
+            t.num_seconds() % 60,
+            (t.num_milliseconds() % 1000) / 10
+        ))
     }
 }
 

--- a/src/uu/w/src/w.rs
+++ b/src/uu/w/src/w.rs
@@ -189,7 +189,7 @@ fn fetch_user_info() -> Result<Vec<UserInfo>, std::io::Error> {
 
 #[cfg(any(target_os = "macos", target_os = "windows"))]
 fn fetch_user_info() -> Result<Vec<UserInfo>, std::io::Error> {
-    Ok(Vec::new())process, 
+    Ok(Vec::new())
 }
 
 #[uucore::main]

--- a/src/uu/w/src/w.rs
+++ b/src/uu/w/src/w.rs
@@ -3,8 +3,6 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
-use std::time::Duration;
-
 #[cfg(target_os = "linux")]
 use chrono::Datelike;
 use clap::crate_version;
@@ -12,7 +10,8 @@ use clap::{Arg, ArgAction, Command};
 #[cfg(target_os = "linux")]
 use libc::{sysconf, _SC_CLK_TCK};
 #[cfg(target_os = "linux")]
-use std::{collections::HashMap, fs, path::Path, process, time::SystemTime};
+use std::{collections::HashMap, fs, path::Path, time::SystemTime};
+use std::{process, time::Duration};
 #[cfg(target_os = "linux")]
 use uucore::utmpx::Utmpx;
 use uucore::{error::UResult, format_usage, help_about, help_usage};
@@ -96,7 +95,7 @@ fn fetch_idle_time(tty: String) -> Result<Duration, std::io::Error> {
 }
 
 #[cfg(not(target_os = "linux"))]
-fn fetch_idle_time(tty: String) -> Result<Duration, std::io::Error> {
+fn fetch_idle_time(_tty: String) -> Result<Duration, std::io::Error> {
     Ok(Duration::ZERO)
 }
 
@@ -190,7 +189,7 @@ fn fetch_user_info() -> Result<Vec<UserInfo>, std::io::Error> {
 
 #[cfg(any(target_os = "macos", target_os = "windows"))]
 fn fetch_user_info() -> Result<Vec<UserInfo>, std::io::Error> {
-    Ok(Vec::new())
+    Ok(Vec::new())process, 
 }
 
 #[uucore::main]

--- a/src/uu/w/src/w.rs
+++ b/src/uu/w/src/w.rs
@@ -95,7 +95,7 @@ fn fetch_idle_time(tty: String) -> Result<Duration, std::io::Error> {
 }
 
 #[cfg(not(target_os = "linux"))]
-fn fetch_idle_time(_tty: String) -> Result<Duration, std::io::Error> {
+fn _fetch_idle_time(_tty: String) -> Result<Duration, std::io::Error> {
     Ok(Duration::ZERO)
 }
 
@@ -312,9 +312,10 @@ pub fn uu_app() -> Command {
 #[cfg(target_os = "linux")]
 mod tests {
     use crate::{
-        fetch_cmdline, fetch_pcpu_time, fetch_terminal_number, format_time, get_clock_tick,
+        fetch_cmdline, fetch_pcpu_time, fetch_terminal_number, format_time, format_time_elapsed,
+        get_clock_tick,
     };
-    use std::{fs, path::Path, process};
+    use std::{fs, path::Path, process, time::Duration};
 
     #[test]
     fn test_format_time() {
@@ -333,6 +334,15 @@ mod tests {
             format_time(pre_formatted).unwrap(),
             td.format("%a%d").to_string()
         )
+    }
+
+    #[test]
+    fn test_format_time_elapsed() {
+        let td = Duration::new(60 * 60 * 18 + 60 * 18, 0);
+        assert_eq!(
+            format_time_elapsed(td, false).unwrap(),
+            String::from("18:18m")
+        );
     }
 
     #[test]

--- a/src/uu/w/src/w.rs
+++ b/src/uu/w/src/w.rs
@@ -23,7 +23,7 @@ struct UserInfo {
     user: String,
     terminal: String,
     login_time: String,
-    idle_time: Duration, // for better compatiability with old-style outputs
+    idle_time: Duration, // for better compatibility with old-style outputs
     jcpu: String,
     pcpu: String,
     command: String,
@@ -99,11 +99,8 @@ fn _fetch_idle_time(_tty: String) -> Result<Duration, std::io::Error> {
     Ok(Duration::ZERO)
 }
 
-fn format_time_elapsed(
-    time: Duration,
-    old_style: bool,
-) -> Result<String, chrono::format::ParseError> {
-    let t = chrono::Duration::from_std(time).unwrap();
+fn format_time_elapsed(time: Duration, old_style: bool) -> Result<String, chrono::OutOfRangeError> {
+    let t = chrono::Duration::from_std(time)?;
     if t.num_days() >= 2 {
         Ok(format!("{}days", t.num_days()))
     } else if t.num_hours() >= 1 {
@@ -342,6 +339,10 @@ mod tests {
         assert_eq!(
             format_time_elapsed(td, false).unwrap(),
             String::from("18:18m")
+        );
+        assert_eq!(
+            format_time_elapsed(td, true).unwrap(),
+            String::from("18:18")
         );
     }
 


### PR DESCRIPTION
This is a basic implementation of the display of each users' idle time, as well as a dedicated time formatting function `format_time_elapsed` for this feature, as my first PR to the `uutils` project.

~~The code's logic is largely based on the original source of procps~~ We'll, no, as that is considered license violation. I mean just the logic is similar, but the code is rather another implementation.