### PR TITLE
watch: handle WATCH_INTERVAL

### DIFF
--- a/src/uu/watch/src/watch.rs
+++ b/src/uu/watch/src/watch.rs
@@ -118,6 +118,7 @@ pub fn uu_app() -> Command {
                 .long("interval")
                 .help("Seconds to wait between updates")
                 .default_value("2")
+                .env("WATCH_INTERVAL")
                 .value_name("SECONDS"),
         )
         .arg(

--- a/tests/by-util/test_watch.rs
+++ b/tests/by-util/test_watch.rs
@@ -14,6 +14,12 @@ const TRUE_CMD: &str = "%SYSTEMROOT%\\System32\\rundll32.exe";
 #[cfg(not(windows))]
 const TRUE_CMD: &str = "true";
 
+#[cfg(windows)]
+const ECHO_HELLO_CMD: &str = "echo | set /p dummyName=hello";
+
+#[cfg(not(windows))]
+const ECHO_HELLO_CMD: &str = "printf hello";
+
 #[test]
 fn test_invalid_arg() {
     new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
@@ -61,4 +67,21 @@ fn test_valid_interval_comma() {
         .with_all_output()
         .no_stderr()
         .no_stdout();
+}
+
+#[test]
+fn test_interval_environment_variable() {
+    let mut p = new_ucmd!()
+        .arg(ECHO_HELLO_CMD)
+        .env("WATCH_INTERVAL", "0.3")
+        .run_no_wait();
+    // With 0.5 seconds runtime, the watched command is called twice if
+    // `WATCH_INTERVAL` (0.3 seconds) is taken into account, but only once if the default
+    // interval (2 seconds) is used.
+    p.make_assertion_with_delay(500).is_alive();
+    p.kill()
+        .make_assertion()
+        .with_all_output()
+        .no_stderr()
+        .stdout_is_bytes(b"hellohello");
 }


### PR DESCRIPTION
Resolves #25.

Handle `WATCH_INTERVAL`, as override for the `-n, --interval` option in `watch`.