### PR TITLE
vmstat: add basic implementation of `vmstat`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "adler2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -250,6 +256,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "crc32fast"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossterm"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -413,6 +428,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 
 [[package]]
+name = "flate2"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11faaf5a5236997af9848be0bef4db95824b1d534ebc64d0f0c6cf3e67bd38dc"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -475,6 +500,12 @@ name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "iana-time-zone"
@@ -624,6 +655,15 @@ name = "memchr"
 version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
+dependencies = [
+ "adler2",
+]
 
 [[package]]
 name = "mio"
@@ -840,6 +880,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "procfs"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc5b72d8145275d844d4b5f6d4e1eef00c8cd889edb6035c21675d1bb1f45c9f"
+dependencies = [
+ "bitflags",
+ "chrono",
+ "flate2",
+ "hex",
+ "procfs-core",
+ "rustix 0.38.40",
+]
+
+[[package]]
+name = "procfs-core"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "239df02d8349b06fc07398a3a1697b06418223b1c7725085e801e7c0fc6a12ec"
+dependencies = [
+ "bitflags",
+ "chrono",
+ "hex",
+]
+
+[[package]]
 name = "procps"
 version = "0.0.1"
 dependencies = [
@@ -870,6 +935,7 @@ dependencies = [
  "uu_sysctl",
  "uu_tload",
  "uu_top",
+ "uu_vmstat",
  "uu_w",
  "uu_watch",
  "uucore",
@@ -1534,6 +1600,15 @@ dependencies = [
  "sysinfo",
  "uucore",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "uu_vmstat"
+version = "0.0.1"
+dependencies = [
+ "clap",
+ "procfs",
+ "uucore",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1598,6 +1598,7 @@ dependencies = [
  "pkg-config",
  "prettytable-rs",
  "sysinfo",
+ "uu_vmstat",
  "uucore",
  "windows-sys 0.59.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ feat_common_core = [
     "sysctl",
     "tload",
     "top",
+    "vmstat",
     "w",
     "watch",
 ]
@@ -55,6 +56,7 @@ nix = { version = "0.29", default-features = false, features = ["process"] }
 phf = "0.11.2"
 phf_codegen = "0.11.2"
 prettytable-rs = "0.10.0"
+procfs = "0.17.0"
 rand = { version = "0.9.0", features = ["small_rng"] }
 ratatui = "0.29.0"
 regex = "1.10.4"
@@ -92,6 +94,7 @@ snice = { optional = true, version = "0.0.1", package = "uu_snice", path = "src/
 sysctl = { optional = true, version = "0.0.1", package = "uu_sysctl", path = "src/uu/sysctl" }
 tload = { optional = true, version = "0.0.1", package = "uu_tload", path = "src/uu/tload" }
 top = { optional = true, version = "0.0.1", package = "uu_top", path = "src/uu/top" }
+vmstat = { optional = true, version = "0.0.1", package = "uu_vmstat", path = "src/uu/vmstat" }
 w = { optional = true, version = "0.0.1", package = "uu_w", path = "src/uu/w" }
 watch = { optional = true, version = "0.0.1", package = "uu_watch", path = "src/uu/watch" }
 

--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ Ongoing:
 * `sysctl`: Read or write kernel parameters at run-time.
 * `tload`: Prints a graphical representation of system load average to the terminal.
 * `top`: Displays real-time information about system processes.
+* `vmstat`: Reports information about processes, memory, paging, block IO, traps, and CPU activity.
 * `w`: Shows who is logged on and what they are doing.
 * `watch`: Executes a program periodically, showing output fullscreen.
 
 TODO:
 * `hugetop`: Report hugepage usage of processes and the system as a whole.
 * `skill`: Sends a signal to processes based on criteria like user, terminal, etc.
-* `vmstat`: Reports information about processes, memory, paging, block IO, traps, and CPU activity.
 
 Elsewhere:
 

--- a/src/uu/top/Cargo.toml
+++ b/src/uu/top/Cargo.toml
@@ -20,11 +20,15 @@ prettytable-rs = { workspace = true }
 sysinfo = { workspace = true }
 chrono = { workspace = true }
 bytesize = { workspace = true }
+
+uu_vmstat = { path = "../vmstat" }
+
 [target.'cfg(target_os="windows")'.dependencies]
 windows-sys = { workspace = true, features = [
     "Win32_System_RemoteDesktop",
     "Win32_System_SystemInformation",
 ] }
+
 
 [target.'cfg(target_os="linux")'.build-dependencies]
 pkg-config = "0.3.31"

--- a/src/uu/top/src/header.rs
+++ b/src/uu/top/src/header.rs
@@ -135,49 +135,18 @@ fn task() -> String {
 
 #[cfg(target_os = "linux")]
 fn cpu() -> String {
-    let file = std::fs::File::open(std::path::Path::new("/proc/stat")).unwrap();
-    let content = std::io::read_to_string(file).unwrap();
-    let load = content
-        .lines()
-        .next()
-        .unwrap()
-        .strip_prefix("cpu")
-        .unwrap()
-        .split(' ')
-        .filter(|s| !s.is_empty())
-        .collect::<Vec<_>>();
-    let user = load[0].parse::<f64>().unwrap();
-    let nice = load[1].parse::<f64>().unwrap();
-    let system = load[2].parse::<f64>().unwrap();
-    let idle = load[3].parse::<f64>().unwrap_or_default(); // since 2.5.41
-    let io_wait = load[4].parse::<f64>().unwrap_or_default(); // since 2.5.41
-    let hardware_interrupt = load[5].parse::<f64>().unwrap_or_default(); // since 2.6.0
-    let software_interrupt = load[6].parse::<f64>().unwrap_or_default(); // since 2.6.0
-    let steal_time = load[7].parse::<f64>().unwrap_or_default(); // since 2.6.11
-                                                                 // GNU do not show guest and guest_nice
-    let guest = load[8].parse::<f64>().unwrap_or_default(); // since 2.6.24
-    let guest_nice = load[9].parse::<f64>().unwrap_or_default(); // since 2.6.33
-    let total = user
-        + nice
-        + system
-        + idle
-        + io_wait
-        + hardware_interrupt
-        + software_interrupt
-        + steal_time
-        + guest
-        + guest_nice;
+    let cpu_load = uu_vmstat::CpuLoad::current();
 
     format!(
         "%Cpu(s):  {:.1} us, {:.1} sy, {:.1} ni, {:.1} id, {:.1} wa, {:.1} hi, {:.1} si, {:.1} st",
-        user / total * 100.0,
-        system / total * 100.0,
-        nice / total * 100.0,
-        idle / total * 100.0,
-        io_wait / total * 100.0,
-        hardware_interrupt / total * 100.0,
-        software_interrupt / total * 100.0,
-        steal_time / total * 100.0,
+        cpu_load.user,
+        cpu_load.system,
+        cpu_load.nice,
+        cpu_load.idle,
+        cpu_load.io_wait,
+        cpu_load.hardware_interrupt,
+        cpu_load.software_interrupt,
+        cpu_load.steal_time,
     )
 }
 

--- a/src/uu/vmstat/Cargo.toml
+++ b/src/uu/vmstat/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "uu_vmstat"
+version = "0.0.1"
+edition = "2021"
+authors = ["uutils developers"]
+license = "MIT"
+description = "vmstat ~ (uutils) Report virtual memory statistics."
+
+homepage = "https://github.com/uutils/procps"
+repository = "https://github.com/uutils/procps/tree/main/src/uu/vmstat"
+keywords = ["acl", "uutils", "cross-platform", "cli", "utility"]
+categories = ["command-line-utilities"]
+
+[dependencies]
+uucore = { workspace = true }
+clap = { workspace = true }
+
+[target.'cfg(target_os="linux")'.dependencies]
+procfs = { workspace = true }
+
+[lib]
+path = "src/vmstat.rs"
+
+[[bin]]
+name = "vmstat"
+path = "src/main.rs"

--- a/src/uu/vmstat/src/main.rs
+++ b/src/uu/vmstat/src/main.rs
@@ -1,0 +1,1 @@
+uucore::bin!(uu_vmstat);

--- a/src/uu/vmstat/src/parser.rs
+++ b/src/uu/vmstat/src/parser.rs
@@ -1,0 +1,78 @@
+#[cfg(target_os = "linux")]
+pub fn parse_proc_file(path: &str) -> std::collections::HashMap<String, String> {
+    let file = std::fs::File::open(std::path::Path::new(path)).unwrap();
+    let content = std::io::read_to_string(file).unwrap();
+    let mut map: std::collections::HashMap<String, String> = std::collections::HashMap::new();
+
+    for line in content.lines() {
+        let parts = line.split_once(char::is_whitespace);
+        if let Some(parts) = parts {
+            map.insert(parts.0.to_string(), parts.1.trim_start().to_string());
+        }
+    }
+
+    map
+}
+
+#[cfg(target_os = "linux")]
+pub struct CpuLoad {
+    pub user: f64,
+    pub nice: f64,
+    pub system: f64,
+    pub idle: f64,
+    pub io_wait: f64,
+    pub hardware_interrupt: f64,
+    pub software_interrupt: f64,
+    pub steal_time: f64,
+    pub guest: f64,
+    pub guest_nice: f64,
+}
+
+#[cfg(target_os = "linux")]
+impl CpuLoad {
+    pub fn current() -> CpuLoad {
+        let file = std::fs::File::open(std::path::Path::new("/proc/stat")).unwrap(); // do not use `parse_proc_file` here because only one line is used
+        let content = std::io::read_to_string(file).unwrap();
+        let load = content
+            .lines()
+            .next()
+            .unwrap()
+            .strip_prefix("cpu")
+            .unwrap()
+            .split(' ')
+            .filter(|s| !s.is_empty())
+            .collect::<Vec<_>>();
+        let user = load[0].parse::<f64>().unwrap();
+        let nice = load[1].parse::<f64>().unwrap();
+        let system = load[2].parse::<f64>().unwrap();
+        let idle = load[3].parse::<f64>().unwrap_or_default(); // since 2.5.41
+        let io_wait = load[4].parse::<f64>().unwrap_or_default(); // since 2.5.41
+        let hardware_interrupt = load[5].parse::<f64>().unwrap_or_default(); // since 2.6.0
+        let software_interrupt = load[6].parse::<f64>().unwrap_or_default(); // since 2.6.0
+        let steal_time = load[7].parse::<f64>().unwrap_or_default(); // since 2.6.11
+        let guest = load[8].parse::<f64>().unwrap_or_default(); // since 2.6.24
+        let guest_nice = load[9].parse::<f64>().unwrap_or_default(); // since 2.6.33
+        let total = user
+            + nice
+            + system
+            + idle
+            + io_wait
+            + hardware_interrupt
+            + software_interrupt
+            + steal_time
+            + guest
+            + guest_nice;
+        Self {
+            user: user / total * 100.0,
+            system: system / total * 100.0,
+            nice: nice / total * 100.0,
+            idle: idle / total * 100.0,
+            io_wait: io_wait / total * 100.0,
+            hardware_interrupt: hardware_interrupt / total * 100.0,
+            software_interrupt: software_interrupt / total * 100.0,
+            steal_time: steal_time / total * 100.0,
+            guest: guest / total * 100.0,
+            guest_nice: guest_nice / total * 100.0,
+        }
+    }
+}

--- a/src/uu/vmstat/src/parser.rs
+++ b/src/uu/vmstat/src/parser.rs
@@ -1,3 +1,8 @@
+// This file is part of the uutils procps package.
+//
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+
 #[cfg(target_os = "linux")]
 pub fn parse_proc_file(path: &str) -> std::collections::HashMap<String, String> {
     let file = std::fs::File::open(std::path::Path::new(path)).unwrap();

--- a/src/uu/vmstat/src/vmstat.rs
+++ b/src/uu/vmstat/src/vmstat.rs
@@ -92,7 +92,7 @@ fn get_memory_info() -> (String, String, String) {
     (
         "-----------memory----------".into(),
         "  swpd   free   buff  cache".into(),
-        format!("{:>6} {:>6} {:>6} {:>6}", swap_used, free, buffer, cache),
+        format!("{:>6} {:>6} {:>5} {:>6}", swap_used, free, buffer, cache),
     )
 }
 
@@ -106,7 +106,7 @@ fn get_swap_info() -> (String, String, String) {
         "---swap--".into(),
         "  si   so".into(),
         format!(
-            "{:>4} {:>4}",
+            "{:>2} {:>4}",
             *swap_in as f64 / uptime,
             *swap_out as f64 / uptime
         ),
@@ -123,7 +123,7 @@ fn get_io_info() -> (String, String, String) {
         "-----io----".into(),
         "   bi    bo".into(),
         format!(
-            "{:>4.0} {:>4.0}",
+            "{:>5.0} {:>5.0}",
             *read_bytes as f64 / uptime,
             *write_bytes as f64 / uptime
         ),

--- a/src/uu/vmstat/src/vmstat.rs
+++ b/src/uu/vmstat/src/vmstat.rs
@@ -1,0 +1,251 @@
+// This file is part of the uutils procps package.
+//
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+
+use clap::{crate_version, Command};
+#[cfg(target_os = "linux")]
+use procfs::{Current, CurrentSI};
+#[cfg(target_os = "linux")]
+use std::collections::HashMap;
+use uucore::error::UResult;
+use uucore::{format_usage, help_about, help_usage};
+
+const ABOUT: &str = help_about!("vmstat.md");
+const USAGE: &str = help_usage!("vmstat.md");
+
+#[uucore::main]
+pub fn uumain(args: impl uucore::Args) -> UResult<()> {
+    let _matches = uu_app().try_get_matches_from(args)?;
+
+    let mut section: Vec<String> = vec![];
+    let mut title: Vec<String> = vec![];
+    let mut data: Vec<String> = vec![];
+
+    #[cfg(target_os = "linux")]
+    let func = [
+        concat_helper(get_process_info),
+        concat_helper(get_memory_info),
+        concat_helper(get_swap_info),
+        concat_helper(get_io_info),
+        concat_helper(get_system_info),
+        concat_helper(get_cpu_info),
+    ];
+
+    #[cfg(not(target_os = "linux"))]
+    let func: [ConcatFunc; 0] = [];
+
+    func.iter()
+        .for_each(|f| f(&mut section, &mut title, &mut data));
+
+    println!("{}", section.join(" "));
+    println!("{}", title.join(" "));
+    println!("{}", data.join(" "));
+
+    Ok(())
+}
+
+type ConcatFunc = Box<dyn Fn(&mut Vec<String>, &mut Vec<String>, &mut Vec<String>)>;
+
+#[allow(dead_code)]
+fn concat_helper(func: impl Fn() -> (String, String, String) + 'static) -> ConcatFunc {
+    Box::from(
+        move |section: &mut Vec<String>, title: &mut Vec<String>, data: &mut Vec<String>| {
+            let output = func();
+            section.push(output.0);
+            title.push(output.1);
+            data.push(output.2);
+        },
+    )
+}
+
+#[cfg(target_os = "linux")]
+fn up_secs() -> f64 {
+    let file = std::fs::File::open(std::path::Path::new("/proc/uptime")).unwrap();
+    let content = std::io::read_to_string(file).unwrap();
+    let mut parts = content.split_whitespace();
+    parts.next().unwrap().parse::<f64>().unwrap()
+}
+
+#[cfg(target_os = "linux")]
+fn up_secs_proc() -> f64 {
+    let stat = parse_proc_file("/proc/stat");
+    let n_proc = stat.keys().filter(|k| k.starts_with("cpu")).count() - 1; // exclude the line `cpu`
+
+    n_proc as f64 * up_secs()
+}
+
+#[cfg(target_os = "linux")]
+fn parse_proc_file(path: &str) -> HashMap<String, String> {
+    let file = std::fs::File::open(std::path::Path::new(path)).unwrap();
+    let content = std::io::read_to_string(file).unwrap();
+    let mut map: HashMap<String, String> = HashMap::new();
+
+    for line in content.lines() {
+        let parts = line.split_once(char::is_whitespace);
+        if let Some(parts) = parts {
+            map.insert(parts.0.to_string(), parts.1.trim_start().to_string());
+        }
+    }
+
+    map
+}
+
+#[cfg(target_os = "linux")]
+fn get_process_info() -> (String, String, String) {
+    let stat = procfs::KernelStats::current().unwrap();
+    let runnable = stat.procs_running.unwrap_or_default();
+    let blocked = stat.procs_blocked.unwrap_or_default();
+    (
+        "procs".into(),
+        " r  b".into(),
+        format!("{:>2} {:>2}", runnable, blocked),
+    )
+}
+
+#[cfg(target_os = "linux")]
+fn get_memory_info() -> (String, String, String) {
+    let memory_info = procfs::Meminfo::current().unwrap();
+    let swap_used = (memory_info.swap_total - memory_info.swap_free) / 1024;
+    let free = memory_info.mem_free / 1024;
+    let buffer = memory_info.buffers / 1024;
+    let cache = memory_info.cached / 1024;
+
+    (
+        "-----------memory----------".into(),
+        "  swpd   free   buff  cache".into(),
+        format!("{:>6} {:>6} {:>6} {:>6}", swap_used, free, buffer, cache),
+    )
+}
+
+#[cfg(target_os = "linux")]
+fn get_swap_info() -> (String, String, String) {
+    let uptime = up_secs_proc();
+    let vmstat = procfs::vmstat().unwrap();
+    let swap_in = vmstat.get("pswpin").unwrap();
+    let swap_out = vmstat.get("pswpout").unwrap();
+    (
+        "---swap--".into(),
+        "  si   so".into(),
+        format!(
+            "{:>4} {:>4}",
+            *swap_in as f64 / uptime,
+            *swap_out as f64 / uptime
+        ),
+    )
+}
+
+#[cfg(target_os = "linux")]
+fn get_io_info() -> (String, String, String) {
+    let uptime = up_secs_proc();
+    let vmstat = procfs::vmstat().unwrap();
+    let read_bytes = vmstat.get("pgpgin").unwrap();
+    let write_bytes = vmstat.get("pgpgout").unwrap();
+    (
+        "----io----".into(),
+        "  bi    bo".into(),
+        format!(
+            "{:>4.0} {:>4.0}",
+            *read_bytes as f64 / uptime,
+            *write_bytes as f64 / uptime
+        ),
+    )
+}
+
+#[cfg(target_os = "linux")]
+fn get_system_info() -> (String, String, String) {
+    let uptime = up_secs_proc();
+    let stat = parse_proc_file("/proc/stat");
+
+    let interrupts = stat
+        .get("intr")
+        .unwrap()
+        .split_whitespace()
+        .next()
+        .unwrap()
+        .parse::<i64>()
+        .unwrap();
+    let context_switches = stat.get("ctxt").unwrap().parse::<i64>().unwrap();
+
+    (
+        "-system--".into(),
+        "  in   cs".into(),
+        format!(
+            "{:>4.0} {:>4.0}",
+            interrupts as f64 / uptime,
+            context_switches as f64 / uptime
+        ),
+    )
+}
+
+#[cfg(target_os = "linux")]
+fn get_cpu_info() -> (String, String, String) {
+    let stat = parse_proc_file("/proc/stat");
+    let load = stat
+        .get("cpu")
+        .unwrap()
+        .split(' ')
+        .filter(|s| !s.is_empty())
+        .collect::<Vec<_>>();
+    let user = load[0].parse::<f64>().unwrap();
+    let nice = load[1].parse::<f64>().unwrap();
+    let system = load[2].parse::<f64>().unwrap();
+    let idle = load[3].parse::<f64>().unwrap_or_default(); // since 2.5.41
+    let io_wait = load[4].parse::<f64>().unwrap_or_default(); // since 2.5.41
+    let hardware_interrupt = load[5].parse::<f64>().unwrap_or_default(); // since 2.6.0
+    let software_interrupt = load[6].parse::<f64>().unwrap_or_default(); // since 2.6.0
+    let steal_time = load[7].parse::<f64>().unwrap_or_default(); // since 2.6.11
+                                                                 // GNU do not show guest and guest_nice
+    let guest = load[8].parse::<f64>().unwrap_or_default(); // since 2.6.24
+    let guest_nice = load[9].parse::<f64>().unwrap_or_default(); // since 2.6.33
+    let total = user
+        + nice
+        + system
+        + idle
+        + io_wait
+        + hardware_interrupt
+        + software_interrupt
+        + steal_time
+        + guest
+        + guest_nice;
+
+    (
+        "------cpu-----".into(),
+        "us sy id wa st".into(),
+        format!(
+            "{:>2.0} {:>2.0} {:>2.0} {:>2.0} {:>2.0}",
+            user / total * 100.0,
+            system / total * 100.0,
+            idle / total * 100.0,
+            io_wait / total * 100.0,
+            steal_time / total * 100.0,
+        ),
+    )
+}
+
+#[allow(clippy::cognitive_complexity)]
+pub fn uu_app() -> Command {
+    Command::new(uucore::util_name())
+        .version(crate_version!())
+        .about(ABOUT)
+        .override_usage(format_usage(USAGE))
+        .infer_long_args(true)
+    // .args([
+    // arg!(<delay> "The delay between updates in seconds").required(false),
+    // arg!(<count> "Number of updates").required(false),
+    // arg!(-a --active "Display active and inactive memory"),
+    // arg!(-f --forks "switch displays the number of forks since boot"),
+    // arg!(-m --slabs "Display slabinfo"),
+    // arg!(-n --one-header "Display the header only once rather than periodically"),
+    // arg!(-s --stats "Displays a table of various event counters and memory statistics"),
+    // arg!(-d --disk "Report disk statistics"),
+    // arg!(-D --disk-sum "Report some summary statistics about disk activity"),
+    // arg!(-p --partition <device> "Detailed statistics about partition"),
+    // arg!(-S --unit <character> "Switches outputs between 1000 (k), 1024 (K), 1000000 (m), or 1048576 (M) bytes"),
+    // arg!(-t --timestamp "Append timestamp to each line"),
+    // arg!(-w --wide "Wide output mode"),
+    // arg!(-y --no-first "Omits first report with statistics since system boot"),
+    // arg!(-V --version "Display version information and exit"),
+    // arg!(-h --help "Display help and exit"),
+    // ])
+}

--- a/src/uu/vmstat/vmstat.md
+++ b/src/uu/vmstat/vmstat.md
@@ -1,0 +1,9 @@
+# vmstat
+
+usage:
+
+```bash
+vmstat [options]
+```
+
+Report virtual memory statistics

--- a/tests/by-util/test_vmstat.rs
+++ b/tests/by-util/test_vmstat.rs
@@ -1,0 +1,16 @@
+// This file is part of the uutils procps package.
+//
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+
+use crate::common::util::TestScenario;
+
+#[test]
+fn test_simple() {
+    new_ucmd!().succeeds();
+}
+
+#[test]
+fn test_invalid_arg() {
+    new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -49,6 +49,10 @@ mod test_pidwait;
 #[path = "by-util/test_top.rs"]
 mod test_top;
 
+#[cfg(feature = "vmstat")]
+#[path = "by-util/test_vmstat.rs"]
+mod test_vmstat;
+
 #[cfg(feature = "snice")]
 #[path = "by-util/test_snice.rs"]
 mod test_snice;


### PR DESCRIPTION
Add basic implementation of `vmstat` on Linux platform.

resolves #33