### PR TITLE
pidof: simplify usage string

### DIFF
--- a/src/uu/pidof/pidof.md
+++ b/src/uu/pidof/pidof.md
@@ -1,7 +1,7 @@
 # pidof
 
 ```
-pidof [-s] [-c] [-n] [-x] [-z] [-o omitpid[,omitpid...]]  [-o omitpid[,omitpid...]...]  [-d sep] program [program...]
+pidof [options] [program [...]]
 ```
 
 Find the process ID of a running program


### PR DESCRIPTION
This PR simplifies the usage string shown when using `--help`, using the same string as the original `pidof`.