### PR TITLE
w: fix column widths

### DIFF
--- a/src/uu/w/src/w.rs
+++ b/src/uu/w/src/w.rs
@@ -204,7 +204,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                     println!("{:<9}{:<9}{:<7}{:<}", "USER", "TTY", "IDLE", "WHAT");
                 } else {
                     println!(
-                        "{:<9}{:<9}{:<9}{:<6} {:<7}{:<5}{:<}",
+                        "{:<9}{:<10}{:<9}{:<6} {:<7}{:<6}{:<}",
                         "USER", "TTY", "LOGIN@", "IDLE", "JCPU", "PCPU", "WHAT"
                     );
                 }
@@ -220,7 +220,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                     );
                 } else {
                     println!(
-                        "{:<9}{:<9}{:<9}{:<6} {:<7}{:<5}{:<}",
+                        "{:<9}{:<10}{:<9}{:<6} {:<7}{:<6}{:<}",
                         user.user,
                         user.terminal,
                         user.login_time,


### PR DESCRIPTION
This PR adapts the column widths of the `TTY` and `PCPU` columns to match those of the original `w`.

Before the change:
```
$ cargo run -q w
USER     TTY      LOGIN@   IDLE   JCPU   PCPU WHAT
...
```
After the change:
```
$ cargo run -q w
USER     TTY       LOGIN@   IDLE   JCPU   PCPU  WHAT
...
```
Original `w` (I omit the first line as we don't have implemented it yet in our version):
```
$ w
USER     TTY       LOGIN@   IDLE   JCPU   PCPU  WHAT
...
```