### PR TITLE
clippy: fix warnings from Rust 1.86

### DIFF
--- a/src/uu/pgrep/src/process.rs
+++ b/src/uu/pgrep/src/process.rs
@@ -79,7 +79,7 @@ impl TryFrom<PathBuf> for Teletype {
         let f = |prefix: &str| {
             value
                 .iter()
-                .last()?
+                .next_back()?
                 .to_str()?
                 .strip_prefix(prefix)?
                 .parse::<u64>()
@@ -229,7 +229,7 @@ impl ProcessInformation {
         let pid = {
             value
                 .iter()
-                .last()
+                .next_back()
                 .ok_or(io::ErrorKind::Other)?
                 .to_str()
                 .ok_or(io::ErrorKind::InvalidData)?

--- a/src/uu/snice/src/snice.rs
+++ b/src/uu/snice/src/snice.rs
@@ -213,7 +213,7 @@ fn construct_verbose_result(pids: &[u32], action_results: &[Option<ActionResult>
 
             let mut cmd = process
                 .exe()
-                .and_then(|it| it.iter().last())
+                .and_then(|it| it.iter().next_back())
                 .unwrap_or("?".as_ref());
             let cmd = cmd.to_str().unwrap();
 

--- a/src/uu/top/src/picker.rs
+++ b/src/uu/top/src/picker.rs
@@ -193,7 +193,7 @@ fn command(pid: u32) -> String {
     };
 
     proc.exe()
-        .and_then(|it| it.iter().last())
+        .and_then(|it| it.iter().next_back())
         .map(|it| it.to_str().unwrap())
         .unwrap_or(&f(proc.cmd()))
         .into()

--- a/src/uu/top/src/top.rs
+++ b/src/uu/top/src/top.rs
@@ -154,7 +154,7 @@ where
         input.chars().take(width).collect()
     } else {
         let mut result = String::from(&input);
-        result.extend(std::iter::repeat(' ').take(width - input.len()));
+        result.extend(std::iter::repeat_n(' ', width - input.len()));
         result
     }
 }

--- a/tests/common/util.rs
+++ b/tests/common/util.rs
@@ -1186,9 +1186,9 @@ impl TestScenario {
 
 /// A `UCommand` is a builder wrapping an individual Command that provides several additional features:
 /// 1. it has convenience functions that are more ergonomic to use for piping in stdin, spawning the command
-///       and asserting on the results.
+///    and asserting on the results.
 /// 2. it tracks arguments provided so that in test cases which may provide variations of an arg in loops
-///     the test failure can display the exact call which preceded an assertion failure.
+///    the test failure can display the exact call which preceded an assertion failure.
 /// 3. it provides convenience construction methods to set the Command uutils utility and temporary directory.
 ///
 /// Per default `UCommand` runs a command given as an argument in a shell, platform independently.


### PR DESCRIPTION
This PR fixes warnings from the [double_ended_iterator_last](https://rust-lang.github.io/rust-clippy/master/index.html#double_ended_iterator_last), [manual_repeat_n](https://rust-lang.github.io/rust-clippy/master/index.html#manual_repeat_n), and [doc_overindented_list_items](https://rust-lang.github.io/rust-clippy/master/index.html#doc_overindented_list_items) lints.