### PR TITLE
Add hugetop command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -923,6 +923,7 @@ dependencies = [
  "tempfile",
  "textwrap",
  "uu_free",
+ "uu_hugetop",
  "uu_pgrep",
  "uu_pidof",
  "uu_pidwait",
@@ -1470,6 +1471,18 @@ dependencies = [
  "sysinfo",
  "uucore",
  "windows 0.61.1",
+]
+
+[[package]]
+name = "uu_hugetop"
+version = "0.0.1"
+dependencies = [
+ "bytesize",
+ "clap",
+ "sysinfo",
+ "uu_pmap",
+ "uu_top",
+ "uucore",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ feat_common_core = [
     "vmstat",
     "w",
     "watch",
+    "hugetop",
 ]
 
 [workspace.dependencies]
@@ -97,6 +98,7 @@ top = { optional = true, version = "0.0.1", package = "uu_top", path = "src/uu/t
 vmstat = { optional = true, version = "0.0.1", package = "uu_vmstat", path = "src/uu/vmstat" }
 w = { optional = true, version = "0.0.1", package = "uu_w", path = "src/uu/w" }
 watch = { optional = true, version = "0.0.1", package = "uu_watch", path = "src/uu/watch" }
+hugetop = {optional = true, version = "0.0.1", package = "uu_hugetop", path = "src/uu/hugetop"}
 
 [dev-dependencies]
 chrono = { workspace = true }

--- a/src/uu/hugetop/Cargo.toml
+++ b/src/uu/hugetop/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "uu_hugetop"
+version = "0.0.1"
+edition = "2021"
+authors = ["uutils developers"]
+license = "MIT"
+description = "hugetop ~ (uutils) Report huge page information"
+
+homepage = "https://github.com/uutils/procps"
+repository = "https://github.com/uutils/procps/tree/main/src/uu/hugetop"
+keywords = ["acl", "uutils", "cross-platform", "cli", "utility"]
+categories = ["command-line-utilities"]
+
+[dependencies]
+bytesize = { workspace = true }
+clap = { workspace = true }
+sysinfo = { workspace = true }
+uucore = { workspace = true }
+uu_pmap = { path = "../pmap" }
+uu_top= { path = "../top" }
+
+#[target.'cfg(target_os="windows")'.dependencies]
+# windows = { workspace = true, features = ["Wdk_System_SystemInformation", "Win32_System_ProcessStatus", "Win32_System_SystemInformation"] }
+
+[lib]
+path = "src/hugetop.rs"
+
+[[bin]]
+name = "hugetop"
+path = "src/main.rs"

--- a/src/uu/hugetop/hugetop.md
+++ b/src/uu/hugetop/hugetop.md
@@ -1,0 +1,7 @@
+# free
+
+```
+free [options]
+```
+
+Display amount of free and used memory in the system

--- a/src/uu/hugetop/src/hugetop.rs
+++ b/src/uu/hugetop/src/hugetop.rs
@@ -1,0 +1,225 @@
+// This file is part of the uutils procps package.
+//
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+
+use clap::{arg, crate_version, ArgAction, Command};
+use std::env;
+use std::fs;
+use std::io::Error;
+use std::path::Path;
+use std::process;
+use uu_pmap::smaps_format_parser::parse_smap_entries;
+use uu_pmap::smaps_format_parser::SmapEntry;
+use uu_top::header;
+use uucore::uptime::get_formatted_time;
+use uucore::{error::UResult, format_usage, help_about, help_usage};
+
+const ABOUT: &str = help_about!("hugetop.md");
+const USAGE: &str = help_usage!("hugetop.md");
+
+#[derive(Debug)]
+struct ProcessHugepageInfo {
+    pid: u32,
+    name: String,
+    entries: Vec<SmapEntry>,
+}
+
+#[derive(Default, Debug)]
+struct HugePageSizeInfo {
+    size_kb: u64,
+    free: u64,
+    total: u64,
+}
+
+impl std::fmt::Display for HugePageSizeInfo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let size_str = match self.size_kb {
+            2048 => "2Mi",
+            1048576 => "1Gi",
+            _ => panic!("{}", self.size_kb),
+        };
+
+        write!(f, "{} - {}/{}", size_str, self.free, self.total)
+    }
+}
+
+fn parse_hugepage() -> Result<Vec<HugePageSizeInfo>, Error> {
+    let parse_hugepage_value = |p: &Path| -> Result<u64, Error> {
+        fs::read_to_string(p)?.trim().parse().map_err(|_| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "Invalid memory info format",
+            )
+        })
+    };
+
+    let info_dir = fs::read_dir("/sys/kernel/mm/hugepages")?;
+
+    let mut sizes = Vec::new();
+
+    for entry in info_dir {
+        let entry = entry?;
+
+        let mut info = HugePageSizeInfo::default();
+
+        info.total = parse_hugepage_value(&entry.path().join("nr_hugepages"))?;
+        info.free = parse_hugepage_value(&entry.path().join("free_hugepages"))?;
+        info.size_kb = entry
+            .file_name()
+            .into_string()
+            .unwrap()
+            .split("-")
+            .nth(1)
+            .unwrap()
+            .replace("kB", "")
+            .parse()
+            .map_err(|_| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "Invalid memory info format",
+                )
+            })?;
+
+        sizes.push(info);
+    }
+
+    Ok(sizes)
+}
+
+fn parse_process_info(p: &fs::DirEntry) -> Option<ProcessHugepageInfo> {
+    let pid_str = p.file_name().into_string().unwrap_or_default();
+
+    // Skip non-PID directories
+    let pid = pid_str.parse::<u32>().ok()?;
+
+    // Parse name
+    let name = fs::read_to_string(p.path().join("status"))
+        .ok()?
+        .lines()
+        .nth(0)
+        .unwrap_or_default()
+        .split(":")
+        .nth(1)
+        .unwrap_or_default()
+        .trim()
+        .to_string();
+
+    let contents = fs::read_to_string(p.path().join("smaps")).ok()?;
+    let smap_entries = parse_smap_entries(&contents).ok()?;
+    let smap_entries: Vec<_> = smap_entries
+        .into_iter()
+        .filter(|entry| entry.kernel_page_size_in_kb >= 2024)
+        .collect();
+
+    if smap_entries.is_empty() {
+        return None;
+    }
+
+    Some(ProcessHugepageInfo {
+        name,
+        pid,
+        entries: smap_entries,
+    })
+}
+
+#[cfg(target_os = "linux")]
+fn parse_process_hugepages() -> Result<Vec<ProcessHugepageInfo>, Error> {
+    let mut processes = Vec::new();
+    let proc_dir = fs::read_dir("/proc")?;
+
+    for entry in proc_dir {
+        let entry = entry?;
+        if let Some(info) = parse_process_info(&entry) {
+            processes.push(info);
+        }
+    }
+
+    Ok(processes)
+}
+
+#[uucore::main]
+pub fn uumain(args: impl uucore::Args) -> UResult<()> {
+    match parse_hugepage() {
+        Ok(sys_info) => match parse_process_hugepages() {
+            Ok(p_info) => {
+                print!("{}", construct_str(sys_info, &p_info,));
+            }
+            Err(e) => {
+                eprintln!("hugetop: failed to read process hugepage info: {}", e);
+                process::exit(1);
+            }
+        },
+        Err(e) => {
+            eprintln!("hugetop: failed to read hugepage info: {}", e);
+            process::exit(1);
+        }
+    }
+
+    Ok(())
+}
+
+pub fn uu_app() -> Command {
+    Command::new(uucore::util_name())
+        .version(crate_version!())
+        .about(ABOUT)
+        .override_usage(format_usage(USAGE))
+        .args_override_self(true)
+        .infer_long_args(true)
+        .disable_help_flag(true)
+        .arg(arg!(--help "display this help and exit").action(ArgAction::SetTrue))
+}
+
+fn construct_str(sys: Vec<HugePageSizeInfo>, processes: &[ProcessHugepageInfo]) -> String {
+    let mut output = String::new();
+
+    output.push_str(&construct_system_str(sys));
+    output.push_str(&format_process_str(processes));
+
+    output
+}
+
+fn format_process_str(processes: &[ProcessHugepageInfo]) -> String {
+    let mut output = String::new();
+    let header = format!(
+        "{:<8} {:<12} {:<12} {:<12}\n",
+        "PID", "Private", "Shared", "Process"
+    );
+
+    output.push_str(&header);
+
+    for process in processes {
+        for smap_entry in &process.entries {
+            output.push_str(&format!(
+                "{:<8} {:<12} {:<12} {:<12}\n",
+                process.pid,
+                smap_entry.private_hugetlb_in_kb,
+                smap_entry.shared_hugetlb_in_kb,
+                process.name
+            ));
+        }
+    }
+
+    output
+}
+
+fn construct_system_str(sys: Vec<HugePageSizeInfo>) -> String {
+    let mut output = String::new();
+    output.push_str(&format!(
+        "top - {time} {uptime}, {user}\n",
+        time = get_formatted_time(),
+        uptime = header::uptime(),
+        user = header::user(),
+    ));
+
+    for (i, info) in sys.iter().enumerate() {
+        if i < sys.len() - 1 {
+            output.push_str(&format!("{}, ", info.to_string()));
+        } else {
+            output.push_str(&info.to_string());
+            output.push('\n');
+        }
+    }
+
+    output
+}

--- a/src/uu/hugetop/src/main.rs
+++ b/src/uu/hugetop/src/main.rs
@@ -1,0 +1,1 @@
+uucore::bin!(uu_hugetop);

--- a/src/uu/pmap/src/pmap.rs
+++ b/src/uu/pmap/src/pmap.rs
@@ -13,7 +13,7 @@ use uucore::error::{set_exit_code, UResult};
 use uucore::{format_usage, help_about, help_usage};
 
 mod maps_format_parser;
-mod smaps_format_parser;
+pub mod smaps_format_parser;
 
 const ABOUT: &str = help_about!("pmap.md");
 const USAGE: &str = help_usage!("pmap.md");

--- a/src/uu/top/src/header.rs
+++ b/src/uu/top/src/header.rs
@@ -39,7 +39,7 @@ fn format_memory(memory_b: u64, unit: u64) -> f64 {
     ByteSize::b(memory_b).0 as f64 / unit as f64
 }
 
-fn uptime() -> String {
+pub fn uptime() -> String {
     get_formated_uptime(None).unwrap_or_default()
 }
 
@@ -91,7 +91,7 @@ pub fn get_nusers_systemd() -> uucore::error::UResult<usize> {
 }
 
 // see: https://gitlab.com/procps-ng/procps/-/blob/4740a0efa79cade867cfc7b32955fe0f75bf5173/library/uptime.c#L63-L115
-fn user() -> String {
+pub fn user() -> String {
     #[cfg(target_os = "linux")]
     if let Ok(nusers) = get_nusers_systemd() {
         return uucore::uptime::format_nusers(nusers);

--- a/src/uu/top/src/top.rs
+++ b/src/uu/top/src/top.rs
@@ -19,7 +19,7 @@ const ABOUT: &str = help_about!("top.md");
 const USAGE: &str = help_usage!("top.md");
 
 mod field;
-mod header;
+pub mod header;
 mod picker;
 
 #[allow(unused)]


### PR DESCRIPTION
The hugetop command displays system-wide hugepage informantion as well as per-process hugepage information.

It has the flags `--human` (for human-readable size output), `--numa` (to display info per numa core), `--delay <N>` (for display refresh) and `--once` (to only display once then exit). For now none of these flags are supported, and we currently only print once and then exit.

The info shown is also very minimal, but it's the same one which is displayed by the original hugetop. Since we get the info from `/proc/meminfo` and `/sys/kernel/mm/hugepages/hugepages-<size>/...` this is not portable at all and only works on linux.