### PR TITLE
top, w: fix uptime format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1655,6 +1655,7 @@ dependencies = [
  "prettytable-rs",
  "sysinfo",
  "uu_vmstat",
+ "uu_w",
  "uucore",
  "windows-sys 0.59.0",
 ]

--- a/src/uu/top/Cargo.toml
+++ b/src/uu/top/Cargo.toml
@@ -22,6 +22,7 @@ chrono = { workspace = true }
 bytesize = { workspace = true }
 
 uu_vmstat = { path = "../vmstat" }
+uu_w = { path = "../w" }
 
 [target.'cfg(target_os="windows")'.dependencies]
 windows-sys = { workspace = true, features = [

--- a/src/uu/top/src/header.rs
+++ b/src/uu/top/src/header.rs
@@ -5,9 +5,8 @@
 
 use crate::picker::sysinfo;
 use bytesize::ByteSize;
-use uucore::uptime::{
-    get_formated_uptime, get_formatted_loadavg, get_formatted_nusers, get_formatted_time,
-};
+use uu_w::get_formatted_uptime_procps;
+use uucore::uptime::{get_formatted_loadavg, get_formatted_nusers, get_formatted_time};
 
 pub(crate) fn header(scale_summary_mem: Option<&String>) -> String {
     format!(
@@ -39,8 +38,9 @@ fn format_memory(memory_b: u64, unit: u64) -> f64 {
     ByteSize::b(memory_b).0 as f64 / unit as f64
 }
 
+#[inline]
 fn uptime() -> String {
-    get_formated_uptime(None).unwrap_or_default()
+    get_formatted_uptime_procps().unwrap_or_default()
 }
 
 #[cfg(target_os = "linux")]


### PR DESCRIPTION
procps uptime format from procps differs from coreutils'. 

for example:

coreutils:

```text
up 00:42
```

procps v4.0.5:

```text
up 42 min
```

also see [coreutils/7757](https://github.com/uutils/coreutils/pull/7757)