### PR TITLE
Cargo.toml: define and use `workspace.package`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 # procps (uutils)
 # * see the repository LICENSE, README, and CONTRIBUTING files for more information
 
-# spell-checker:ignore (libs) bigdecimal datetime fundu gethostid kqueue libselinux mangen memmap procfs uuhelp
+# spell-checker:ignore (libs) mangen
 
 [workspace.package]
 authors = ["uutils developers"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,23 +3,29 @@
 
 # spell-checker:ignore (libs) bigdecimal datetime fundu gethostid kqueue libselinux mangen memmap procfs uuhelp
 
+[workspace.package]
+authors = ["uutils developers"]
+categories = ["command-line-utilities"]
+edition = "2021"
+homepage = "https://github.com/uutils/procps"
+keywords = ["procps", "uutils", "cross-platform", "cli", "utility"]
+license = "MIT"
+version = "0.0.1"
+
 [package]
 name = "procps"
-version = "0.0.1"
-authors = ["uutils developers"]
-license = "MIT"
 description = "procps ~ implemented as universal (cross-platform) utils, written in Rust"
 default-run = "procps"
-
-homepage = "https://github.com/uutils/procps"
 repository = "https://github.com/uutils/procps"
 readme = "README.md"
-keywords = ["procps", "uutils", "cross-platform", "cli", "utility"]
-categories = ["command-line-utilities"]
-rust-version = "1.70.0"
-edition = "2021"
-
 build = "build.rs"
+authors.workspace = true
+categories.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+version.workspace = true
 
 [features]
 default = ["feat_common_core"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ clap = { version = "4.5.4", features = ["wrap_help", "cargo"] }
 clap_complete = "4.5.2"
 clap_mangen = "0.2.20"
 crossterm = "0.29.0"
+ctor = "0.4.1"
 libc = "0.2.154"
 nix = { version = "0.29", default-features = false, features = ["process"] }
 phf = "0.11.2"
@@ -72,7 +73,6 @@ textwrap = { version = "0.16.1", features = ["terminal_size"] }
 thiserror = "2.0.4"
 uucore = "0.0.30"
 uutests = "0.0.30"
-ctor = "0.4.1"
 walkdir = "2.5.0"
 windows = { version = "0.61.1" }
 windows-sys = { version = "0.59.0", default-features = false }
@@ -108,14 +108,14 @@ watch = { optional = true, version = "0.0.1", package = "uu_watch", path = "src/
 
 [dev-dependencies]
 chrono = { workspace = true }
+ctor = { workspace = true }
 libc = { workspace = true }
 pretty_assertions = "1.4.0"
 rand = { workspace = true }
 regex = { workspace = true }
 tempfile = { workspace = true }
-ctor = { workspace = true }
-uutests = { workspace = true }
 uucore = { workspace = true, features = ["entries", "process", "signals"] }
+uutests = { workspace = true }
 
 [target.'cfg(unix)'.dev-dependencies]
 xattr = { workspace = true }

--- a/src/uu/free/Cargo.toml
+++ b/src/uu/free/Cargo.toml
@@ -1,15 +1,14 @@
 [package]
 name = "uu_free"
-version = "0.0.1"
-edition = "2021"
-authors = ["uutils developers"]
-license = "MIT"
 description = "free ~ (uutils) Display amount of free and used memory in the system"
-
-homepage = "https://github.com/uutils/procps"
 repository = "https://github.com/uutils/procps/tree/main/src/uu/free"
-keywords = ["acl", "uutils", "cross-platform", "cli", "utility"]
-categories = ["command-line-utilities"]
+authors.workspace = true
+categories.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+version.workspace = true
 
 [dependencies]
 bytesize = { workspace = true }

--- a/src/uu/pgrep/Cargo.toml
+++ b/src/uu/pgrep/Cargo.toml
@@ -1,16 +1,14 @@
 [package]
 name = "uu_pgrep"
-version = "0.0.1"
-edition = "2021"
-authors = ["uutils developers"]
-license = "MIT"
 description = "pgrep ~ (uutils) look up, signal, or wait for processes based on name and other attributes"
-
-homepage = "https://github.com/uutils/procps"
 repository = "https://github.com/uutils/procps/tree/main/src/uu/pgrep"
-keywords = ["acl", "uutils", "cross-platform", "cli", "utility"]
-categories = ["command-line-utilities"]
-
+authors.workspace = true
+categories.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+version.workspace = true
 
 [dependencies]
 uucore = { workspace = true, features = ["entries"] }

--- a/src/uu/pidof/Cargo.toml
+++ b/src/uu/pidof/Cargo.toml
@@ -1,16 +1,14 @@
 [package]
 name = "uu_pidof"
-version = "0.0.1"
-edition = "2021"
-authors = ["uutils developers"]
-license = "MIT"
 description = "pidof ~ (uutils) Find the process ID of a running program"
-
-homepage = "https://github.com/uutils/procps"
 repository = "https://github.com/uutils/procps/tree/main/src/uu/pidof"
-keywords = ["acl", "uutils", "cross-platform", "cli", "utility"]
-categories = ["command-line-utilities"]
-
+authors.workspace = true
+categories.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+version.workspace = true
 
 [dependencies]
 uucore = { workspace = true, features = ["process"] }

--- a/src/uu/pidwait/Cargo.toml
+++ b/src/uu/pidwait/Cargo.toml
@@ -1,16 +1,14 @@
 [package]
 name = "uu_pidwait"
-version = "0.0.1"
-edition = "2021"
-authors = ["uutils developers"]
-license = "MIT"
 description = "pidwait ~ (uutils) Wait for processes based on name"
-
-homepage = "https://github.com/uutils/procps"
 repository = "https://github.com/uutils/procps/tree/main/src/uu/pidwait"
-keywords = ["acl", "uutils", "cross-platform", "cli", "utility"]
-categories = ["command-line-utilities"]
-
+authors.workspace = true
+categories.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+version.workspace = true
 
 [dependencies]
 nix = { workspace = true }

--- a/src/uu/pkill/Cargo.toml
+++ b/src/uu/pkill/Cargo.toml
@@ -1,16 +1,14 @@
 [package]
 name = "uu_pkill"
-version = "0.0.1"
-edition = "2021"
-authors = ["uutils developers"]
-license = "MIT"
 description = "pgrep ~ (uutils) Kills processes based on name and other attributes."
-
-homepage = "https://github.com/uutils/procps"
 repository = "https://github.com/uutils/procps/tree/main/src/uu/pkill"
-keywords = ["acl", "uutils", "cross-platform", "cli", "utility"]
-categories = ["command-line-utilities"]
-
+authors.workspace = true
+categories.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+version.workspace = true
 
 [dependencies]
 uucore = { workspace = true, features = ["entries"] }

--- a/src/uu/pmap/Cargo.toml
+++ b/src/uu/pmap/Cargo.toml
@@ -1,16 +1,14 @@
 [package]
 name = "uu_pmap"
-version = "0.0.1"
-edition = "2021"
-authors = ["uutils developers"]
-license = "MIT"
 description = "pmap ~ (uutils) Report memory map of a process"
-
-homepage = "https://github.com/uutils/procps"
 repository = "https://github.com/uutils/procps/tree/main/src/uu/pmap"
-keywords = ["acl", "uutils", "cross-platform", "cli", "utility"]
-categories = ["command-line-utilities"]
-
+authors.workspace = true
+categories.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+version.workspace = true
 
 [dependencies]
 uucore = { workspace = true }

--- a/src/uu/ps/Cargo.toml
+++ b/src/uu/ps/Cargo.toml
@@ -1,15 +1,14 @@
 [package]
 name = "uu_ps"
-version = "0.0.1"
-edition = "2021"
-authors = ["uutils developers"]
-license = "MIT"
 description = "ps - (uutils) Report a snapshot of the current processes"
-
-homepage = "https://github.com/uutils/procps"
 repository = "https://github.com/uutils/procps/tree/main/src/uu/ps"
-keywords = ["acl", "uutils", "cross-platform", "cli", "utility"]
-categories = ["command-line-utilities"]
+authors.workspace = true
+categories.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+version.workspace = true
 
 [dependencies]
 uucore = { workspace = true, features = ["utmpx"] }

--- a/src/uu/pwdx/Cargo.toml
+++ b/src/uu/pwdx/Cargo.toml
@@ -1,15 +1,14 @@
 [package]
 name = "uu_pwdx"
-version = "0.0.1"
-edition = "2021"
-authors = ["uutils developers"]
-license = "MIT"
 description = "pwdx ~ (uutils) Report current working directory of a process"
-
-homepage = "https://github.com/uutils/procps"
 repository = "https://github.com/uutils/procps/tree/main/src/uu/pwdx"
-keywords = ["acl", "uutils", "cross-platform", "cli", "utility"]
-categories = ["command-line-utilities"]
+authors.workspace = true
+categories.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+version.workspace = true
 
 [dependencies]
 uucore = { workspace = true }

--- a/src/uu/slabtop/Cargo.toml
+++ b/src/uu/slabtop/Cargo.toml
@@ -1,16 +1,14 @@
 [package]
 name = "uu_slabtop"
-version = "0.0.1"
-edition = "2021"
-authors = ["uutils developers"]
-license = "MIT"
 description = "slabtop ~ (uutils) Display kernel slab cache information in real time"
-
-homepage = "https://github.com/uutils/procps"
 repository = "https://github.com/uutils/procps/tree/main/src/uu/slabtop"
-keywords = ["acl", "uutils", "cross-platform", "cli", "utility"]
-categories = ["command-line-utilities"]
-
+authors.workspace = true
+categories.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+version.workspace = true
 
 [dependencies]
 uucore = { workspace = true }

--- a/src/uu/snice/Cargo.toml
+++ b/src/uu/snice/Cargo.toml
@@ -1,15 +1,14 @@
 [package]
 name = "uu_snice"
-version = "0.0.1"
-edition = "2021"
-authors = ["uutils developers"]
-license = "MIT"
 description = "snice - (uutils) send a signal or report process status"
-
-homepage = "https://github.com/uutils/procps"
 repository = "https://github.com/uutils/procps/tree/main/src/uu/snice"
-keywords = ["acl", "uutils", "cross-platform", "cli", "utility"]
-categories = ["command-line-utilities"]
+authors.workspace = true
+categories.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+version.workspace = true
 
 [dependencies]
 uucore = { workspace = true, features = ["signals"] }

--- a/src/uu/sysctl/Cargo.toml
+++ b/src/uu/sysctl/Cargo.toml
@@ -1,15 +1,14 @@
 [package]
 name = "uu_sysctl"
-version = "0.0.1"
-edition = "2021"
-authors = ["uutils developers"]
-license = "MIT"
 description = "sysctl ~ (uutils) Show or modify kernel parameters at runtime"
-
-homepage = "https://github.com/uutils/procps"
 repository = "https://github.com/uutils/procps/tree/main/src/uu/sysctl"
-keywords = ["acl", "uutils", "cross-platform", "cli", "utility"]
-categories = ["command-line-utilities"]
+authors.workspace = true
+categories.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+version.workspace = true
 
 [dependencies]
 uucore = { workspace = true }

--- a/src/uu/tload/Cargo.toml
+++ b/src/uu/tload/Cargo.toml
@@ -1,15 +1,14 @@
 [package]
 name = "uu_tload"
-version = "0.0.1"
-edition = "2021"
-authors = ["uutils developers"]
-license = "MIT"
 description = "tload ~ (uutils) graphic representation of system load average"
-
-homepage = "https://github.com/uutils/procps"
 repository = "https://github.com/uutils/procps/tree/main/src/uu/tload"
-keywords = ["acl", "uutils", "cross-platform", "cli", "utility"]
-categories = ["command-line-utilities"]
+authors.workspace = true
+categories.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+version.workspace = true
 
 [dependencies]
 clap = { workspace = true }

--- a/src/uu/top/Cargo.toml
+++ b/src/uu/top/Cargo.toml
@@ -1,15 +1,14 @@
 [package]
 name = "uu_top"
-version = "0.0.1"
-edition = "2021"
-authors = ["uutils developers"]
-license = "MIT"
 description = "top ~ (uutils) Display Linux processes"
-
-homepage = "https://github.com/uutils/procps"
 repository = "https://github.com/uutils/procps/tree/main/src/uu/top"
-keywords = ["acl", "uutils", "cross-platform", "cli", "utility"]
-categories = ["command-line-utilities"]
+authors.workspace = true
+categories.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+version.workspace = true
 
 [dependencies]
 uucore = { workspace = true, features = ["utmpx", "uptime"] }

--- a/src/uu/vmstat/Cargo.toml
+++ b/src/uu/vmstat/Cargo.toml
@@ -1,15 +1,14 @@
 [package]
 name = "uu_vmstat"
-version = "0.0.1"
-edition = "2021"
-authors = ["uutils developers"]
-license = "MIT"
 description = "vmstat ~ (uutils) Report virtual memory statistics."
-
-homepage = "https://github.com/uutils/procps"
 repository = "https://github.com/uutils/procps/tree/main/src/uu/vmstat"
-keywords = ["acl", "uutils", "cross-platform", "cli", "utility"]
-categories = ["command-line-utilities"]
+authors.workspace = true
+categories.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+version.workspace = true
 
 [dependencies]
 bytesize = { workspace = true }

--- a/src/uu/w/Cargo.toml
+++ b/src/uu/w/Cargo.toml
@@ -1,15 +1,14 @@
 [package]
 name = "uu_w"
-version = "0.0.1"
-edition = "2021"
-authors = ["uutils developers"]
-license = "MIT"
 description = "w ~ (uutils) Show who is logged on and what they are doing"
-
-homepage = "https://github.com/uutils/procps"
 repository = "https://github.com/uutils/procps/tree/main/src/uu/w"
-keywords = ["acl", "uutils", "cross-platform", "cli", "utility"]
-categories = ["command-line-utilities"]
+authors.workspace = true
+categories.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+version.workspace = true
 
 [dependencies]
 uucore = { workspace = true, features = ["utmpx", "uptime"] }

--- a/src/uu/watch/Cargo.toml
+++ b/src/uu/watch/Cargo.toml
@@ -1,15 +1,14 @@
 [package]
 name = "uu_watch"
-version = "0.0.1"
-edition = "2021"
-authors = ["uutils developers"]
-license = "MIT"
 description = "watch ~ (uutils) Execute a program periodically, showing output fullscreen"
-
-homepage = "https://github.com/uutils/procps"
 repository = "https://github.com/uutils/procps/tree/main/src/uu/watch"
-keywords = ["acl", "uutils", "cross-platform", "cli", "utility"]
-categories = ["command-line-utilities"]
+authors.workspace = true
+categories.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+version.workspace = true
 
 [dependencies]
 uucore = { workspace = true }


### PR DESCRIPTION
This PR defines a `workspace.package` in the root `Cargo.toml` and uses its values in the `Cargo.toml` files of all tools.