### PR TITLE
Bump `nix` from `0.29.0` to `0.30.1`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -756,6 +756,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "ntapi"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1563,7 +1575,7 @@ name = "uu_pidwait"
 version = "0.0.1"
 dependencies = [
  "clap",
- "nix",
+ "nix 0.30.1",
  "regex",
  "uu_pgrep",
  "uucore",
@@ -1574,7 +1586,7 @@ name = "uu_pkill"
 version = "0.0.1"
 dependencies = [
  "clap",
- "nix",
+ "nix 0.30.1",
  "regex",
  "uu_pgrep",
  "uucore",
@@ -1596,7 +1608,7 @@ dependencies = [
  "chrono",
  "clap",
  "libc",
- "nix",
+ "nix 0.30.1",
  "prettytable-rs",
  "uu_pgrep",
  "uucore",
@@ -1625,7 +1637,7 @@ version = "0.0.1"
 dependencies = [
  "clap",
  "libc",
- "nix",
+ "nix 0.30.1",
  "prettytable-rs",
  "sysinfo",
  "thiserror 2.0.12",
@@ -1661,7 +1673,7 @@ dependencies = [
  "chrono",
  "clap",
  "libc",
- "nix",
+ "nix 0.30.1",
  "pkg-config",
  "prettytable-rs",
  "sysinfo",
@@ -1712,7 +1724,7 @@ dependencies = [
  "glob",
  "iana-time-zone",
  "libc",
- "nix",
+ "nix 0.29.0",
  "number_prefix",
  "os_display",
  "thiserror 2.0.12",
@@ -1749,7 +1761,7 @@ dependencies = [
  "ctor",
  "glob",
  "libc",
- "nix",
+ "nix 0.29.0",
  "pretty_assertions",
  "rand 0.9.1",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ clap_complete = "4.5.2"
 clap_mangen = "0.2.20"
 crossterm = "0.29.0"
 libc = "0.2.154"
-nix = { version = "0.29", default-features = false, features = ["process"] }
+nix = { version = "0.30", default-features = false, features = ["process"] }
 phf = "0.11.2"
 phf_codegen = "0.11.2"
 prettytable-rs = "0.10.0"


### PR DESCRIPTION
This PR manually bumps `nix` from `0.29.0` to <del>`0.30.0`</del>`0.30.1` because renovate shows an "Artifact update problem" error in https://github.com/uutils/procps/pull/406