### PR TITLE
ci: remove hardcoded version of `crossbeam-epoch`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,9 +88,6 @@ jobs:
       run: |
         git clone https://github.com/mozilla/grcov.git ~/grcov/
         cd ~/grcov
-        # Hardcode the version of crossbeam-epoch. See
-        # https://github.com/uutils/coreutils/issues/3680
-        sed -i -e "s|tempfile =|crossbeam-epoch = \"=0.9.8\"\ntempfile =|" Cargo.toml
         cargo install --path .
         cd -
 # Uncomment when the upstream issue


### PR DESCRIPTION
In the CI we specify the version of `crossbeam-epoch` as a workaround for some issue. This PR removes this workaround in order to see whether it is still needed.