### PR TITLE
w: truncate long username

### DIFF
--- a/src/uu/w/src/w.rs
+++ b/src/uu/w/src/w.rs
@@ -255,6 +255,10 @@ fn fetch_user_info() -> Result<Vec<UserInfo>, std::io::Error> {
     Ok(Vec::new())
 }
 
+fn truncate_username(user: &str) -> String {
+    user.chars().take(8).collect::<String>()
+}
+
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let matches = uu_app().try_get_matches_from(args)?;
@@ -281,7 +285,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                 if short {
                     println!(
                         "{:<9}{:<9}{:<7}{:<}",
-                        user.user,
+                        truncate_username(&user.user),
                         user.terminal,
                         format_time_elapsed(user.idle_time, old_style).unwrap_or_default(),
                         user.command
@@ -289,7 +293,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                 } else {
                     println!(
                         "{:<9}{:<10}{:<9}{:<6} {:<7}{:<6}{:<}",
-                        user.user,
+                        truncate_username(&user.user),
                         user.terminal,
                         user.login_time,
                         format_time_elapsed(user.idle_time, old_style).unwrap_or_default(),


### PR DESCRIPTION
my username is `bluemangoo`

```
cargo run -q w
 16:57:30 up  7:06,  4 users,  load average: 1.48, 1.07, 0.96
USER     TTY       LOGIN@   IDLE   JCPU   PCPU  WHAT
bluemang tty1      09:51    7:06m  0.05   0.05  /usr/bin/startplasma-wayland
bluemang pts/0     09:51    7:06m  8241.887.48  /usr/bin/kded5
bluemang pts/2     16:28    28:05  0.48   0.4   /usr/bin/zsh
bluemang pts/3     16:28    28:38  0.25   0.17  /usr/bin/zsh
```

fix #438 