### PR TITLE
pkill: implement `--queue`

### DIFF
--- a/tests/by-util/test_pkill.rs
+++ b/tests/by-util/test_pkill.rs
@@ -74,3 +74,9 @@ fn test_too_long_pattern() {
         .code_is(1)
         .stderr_contains("pattern that searches for process name longer than 15 characters will result in zero matches");
 }
+
+#[test]
+#[cfg(target_os = "linux")]
+fn test_invalid_queue() {
+    new_ucmd!().args(&["-q"]).fails().code_is(1);
+}


### PR DESCRIPTION
wrote a tool to test:

```
$ ./sigr                    
I'm 99648
recv a sig = 2 data = 10 data = 10
```

```
$ cargo run -q pkill -SIGINT -q 10 sigr -e
./sigr killed (pid 99648)
```
