### PR TITLE
vmstat: implement `--slabs`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1881,6 +1881,7 @@ dependencies = [
  "chrono",
  "clap",
  "terminal_size",
+ "uu_slabtop",
  "uucore",
 ]
 

--- a/src/uu/slabtop/src/parse.rs
+++ b/src/uu/slabtop/src/parse.rs
@@ -10,9 +10,9 @@ use std::{
 };
 
 #[derive(Debug, Default)]
-pub(crate) struct SlabInfo {
-    pub(crate) meta: Vec<String>,
-    pub(crate) data: Vec<(String, Vec<u64>)>,
+pub struct SlabInfo {
+    pub meta: Vec<String>,
+    pub data: Vec<(String, Vec<u64>)>,
 }
 
 impl SlabInfo {

--- a/src/uu/slabtop/src/slabtop.rs
+++ b/src/uu/slabtop/src/slabtop.rs
@@ -3,7 +3,7 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
-use crate::parse::SlabInfo;
+pub use crate::parse::SlabInfo;
 use clap::{arg, crate_version, ArgAction, Command};
 use uucore::{error::UResult, format_usage, help_about, help_section, help_usage};
 
@@ -24,6 +24,8 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         .unwrap_or(&'o');
 
     let slabinfo = SlabInfo::new()?.sort(*sort_flag, false);
+
+    println!("{slabinfo:?}");
 
     if matches.get_flag("once") {
         output_header(&slabinfo);

--- a/src/uu/vmstat/Cargo.toml
+++ b/src/uu/vmstat/Cargo.toml
@@ -17,6 +17,8 @@ clap = { workspace = true }
 terminal_size = { workspace = true }
 uucore = { workspace = true, features = ["custom-tz-fmt"] }
 
+uu_slabtop = {path = "../slabtop"}
+
 [lib]
 path = "src/vmstat.rs"
 


### PR DESCRIPTION
remains a sort issue. I have no idea about how GNU implementation sort it by name, especially the priority of `-`

parts of GNU outputs:

```
bio-128                     672    672    192     42
bio-192                    1024   1024    256     32
bio-224                      32     32    256     32
bio-256                      50     50    320     25
bio-352                    2058   2184    384     42
biovec-128                   16     16   2048     16
biovec-64                   512    512   1024     32
biovec-max                  416    448   4096      8
```

```
dmaengine-unmap-128        3450   4830   1088     30
dmaengine-unmap-256          15     15   2112     15
dma-kmalloc-128               0      0    128     32
dma-kmalloc-16                0      0     16    256
dma-kmalloc-192               0      0    192     42
dma-kmalloc-1k                0      0   1024     32
dma-kmalloc-256               0      0    256     32
dma-kmalloc-2k                0      0   2048     16
dma-kmalloc-32                0      0     32    128
dma-kmalloc-4k                0      0   4096      8
dma-kmalloc-512               0      0    512     32
dma-kmalloc-64                0      0     64     64
dma-kmalloc-8                 0      0      8    512
dma-kmalloc-8k                0      0   8192      4
dma-kmalloc-96                0      0     96     42
dm_uevent                     0      0   2888     11
```