### PR TITLE
vmstat: implement `--disk` `--disk-sum` `--partition`

### DIFF
--- a/src/uu/vmstat/src/vmstat.rs
+++ b/src/uu/vmstat/src/vmstat.rs
@@ -7,7 +7,7 @@ mod parser;
 mod picker;
 
 #[cfg(target_os = "linux")]
-use crate::picker::{get_pickers, get_stats, Picker};
+use crate::picker::{get_disk_sum, get_pickers, get_stats, Picker};
 use clap::value_parser;
 #[allow(unused_imports)]
 use clap::{arg, crate_version, ArgMatches, Command};
@@ -26,21 +26,30 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let matches = uu_app().try_get_matches_from(args)?;
     #[cfg(target_os = "linux")]
     {
-        if matches.get_flag("forks") {
-            return print_forks();
-        }
-        if matches.get_flag("stats") {
-            return print_stats();
-        }
-
+        let wide = matches.get_flag("wide");
         let one_header = matches.get_flag("one-header");
         let no_first = matches.get_flag("no-first");
         let term_height = terminal_size::terminal_size()
             .map(|size| size.1 .0)
             .unwrap_or(0);
 
+        if matches.get_flag("forks") {
+            return print_forks();
+        }
         if matches.get_flag("slabs") {
             return print_slabs(one_header, term_height);
+        }
+        if matches.get_flag("stats") {
+            return print_stats();
+        }
+        if matches.get_flag("disk") {
+            return print_disk(wide, one_header, term_height);
+        }
+        if matches.get_flag("disk-sum") {
+            return print_disk_sum();
+        }
+        if let Some(device) = matches.get_one::<String>("partition") {
+            return print_partition(device);
         }
 
         // validate unit
@@ -142,6 +151,110 @@ fn print_slab_header() {
 }
 
 #[cfg(target_os = "linux")]
+fn print_disk_header(wide: bool) {
+    if wide {
+        println!("disk- -------------------reads------------------- -------------------writes------------------ ------IO-------");
+        println!(
+            "{:>15} {:>9} {:>11} {:>11} {:>9} {:>9} {:>11} {:>11} {:>7} {:>7}",
+            "total", "merged", "sectors", "ms", "total", "merged", "sectors", "ms", "cur", "sec"
+        );
+    } else {
+        println!("disk- ------------reads------------ ------------writes----------- -----IO------");
+        println!(
+            "{:>12} {:>6} {:>7} {:>7} {:>6} {:>6} {:>7} {:>7} {:>6} {:>6}",
+            "total", "merged", "sectors", "ms", "total", "merged", "sectors", "ms", "cur", "sec"
+        );
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn print_disk(wide: bool, one_header: bool, term_height: u16) -> UResult<()> {
+    let disk_data = DiskStat::current()
+        .map_err(|_| USimpleError::new(1, "Unable to retrieve disk statistics"))?;
+
+    let mut line_count = 0;
+
+    print_disk_header(wide);
+
+    for disk in disk_data {
+        if !disk.is_disk() {
+            continue;
+        }
+
+        if needs_header(one_header, term_height, line_count) {
+            print_disk_header(wide);
+        }
+        line_count += 1;
+
+        if wide {
+            println!(
+                "{:<5} {:>9} {:>9} {:>11} {:>11} {:>9} {:>9} {:>11} {:>11} {:>7} {:>7}",
+                disk.device,
+                disk.reads_completed,
+                disk.reads_merged,
+                disk.sectors_read,
+                disk.milliseconds_spent_reading,
+                disk.writes_completed,
+                disk.writes_merged,
+                disk.sectors_written,
+                disk.milliseconds_spent_writing,
+                disk.ios_currently_in_progress / 1000,
+                disk.milliseconds_spent_doing_ios / 1000
+            );
+        } else {
+            println!(
+                "{:<5} {:>6} {:>6} {:>7} {:>7} {:>6} {:>6} {:>7} {:>7} {:>6} {:>6}",
+                disk.device,
+                disk.reads_completed,
+                disk.reads_merged,
+                disk.sectors_read,
+                disk.milliseconds_spent_reading,
+                disk.writes_completed,
+                disk.writes_merged,
+                disk.sectors_written,
+                disk.milliseconds_spent_writing,
+                disk.ios_currently_in_progress / 1000,
+                disk.milliseconds_spent_doing_ios / 1000
+            );
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn print_disk_sum() -> UResult<()> {
+    let data = get_disk_sum()?;
+
+    data.iter()
+        .for_each(|(name, value)| println!("{value:>13} {name}"));
+
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn print_partition(device: &str) -> UResult<()> {
+    let disk_data = DiskStat::current()
+        .map_err(|_| USimpleError::new(1, "Unable to retrieve disk statistics"))?;
+
+    let disk = disk_data
+        .iter()
+        .find(|disk| disk.device == device)
+        .ok_or_else(|| USimpleError::new(1, format!("Disk/Partition {device} not found")))?;
+
+    println!(
+        "{device:<9} {:>11} {:>17} {:>11} {:>17}",
+        "reads", "read sectors", "writes", "requested writes"
+    );
+    println!(
+        "{:>21} {:>17} {:>11} {:>17}",
+        disk.reads_completed, disk.sectors_read, disk.writes_completed, disk.sectors_written
+    );
+
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
 fn print_header(pickers: &[Picker]) {
     let mut section: Vec<&str> = vec![];
     let mut title: Vec<&str> = vec![];
@@ -191,15 +304,18 @@ pub fn uu_app() -> Command {
                 .value_parser(value_parser!(u64)),
             arg!(-a --active "Display active and inactive memory"),
             arg!(-f --forks "switch displays the number of forks since boot")
-                .conflicts_with_all(["slabs", "stats", /*"disk", "disk-sum", "partition"*/]),
+                .conflicts_with_all(["slabs", "stats", "disk", "disk-sum", "partition"]),
             arg!(-m --slabs "Display slabinfo")
-                .conflicts_with_all(["forks", "stats", /*"disk", "disk-sum", "partition"*/]),
+                .conflicts_with_all(["forks", "stats", "disk", "disk-sum", "partition"]),
             arg!(-n --"one-header" "Display the header only once rather than periodically"),
             arg!(-s --stats "Displays a table of various event counters and memory statistics")
-                .conflicts_with_all(["forks", "slabs", /*"disk", "disk-sum", "partition"*/]),
-            // arg!(-d --disk "Report disk statistics"),
-            // arg!(-D --"disk-sum" "Report some summary statistics about disk activity"),
-            // arg!(-p --partition <device> "Detailed statistics about partition"),
+                .conflicts_with_all(["forks", "slabs", "disk", "disk-sum", "partition"]),
+            arg!(-d --disk "Report disk statistics")
+                .conflicts_with_all(["forks", "slabs", "stats", "disk-sum", "partition"]),
+            arg!(-D --"disk-sum" "Report some summary statistics about disk activity")
+                .conflicts_with_all(["forks", "slabs", "stats", "disk", "partition"]),
+            arg!(-p --partition <device> "Detailed statistics about partition")
+                .conflicts_with_all(["forks", "slabs", "stats", "disk", "disk-sum"]),
             arg!(-S --unit <character> "Switches outputs between 1000 (k), 1024 (K), 1000000 (m), or 1048576 (M) bytes"),
             arg!(-t --timestamp "Append timestamp to each line"),
             arg!(-w --wide "Wide output mode"),

--- a/tests/by-util/test_vmstat.rs
+++ b/tests/by-util/test_vmstat.rs
@@ -92,3 +92,15 @@ fn test_timestamp() {
 fn test_stats() {
     new_ucmd!().arg("-s").succeeds();
 }
+
+#[test]
+#[cfg(target_os = "linux")]
+fn test_disk() {
+    new_ucmd!().arg("-d").succeeds();
+}
+
+#[test]
+#[cfg(target_os = "linux")]
+fn test_disk_sum() {
+    new_ucmd!().arg("-D").succeeds();
+}


### PR DESCRIPTION
This PR implemented `--disk`(`-d`), `--disk-sum`(`-D`), `--partition <device>`(`-p`).

So far, **all** the features of vmstat **on Linux** have been implemented.

```
$ cargo run -q vmstat -d && echo '\n' && vmstat -d
disk- ------------reads------------ ------------writes----------- -----IO------
       total merged sectors      ms  total merged sectors      ms    cur    sec
nvme0n1  87787    629 15882401   47181 756219  25189 60103306 1911481      0    246
loop0      0      0       0       0      0      0       0       0      0      0
loop1      0      0       0       0      0      0       0       0      0      0
loop2      0      0       0       0      0      0       0       0      0      0
loop3      0      0       0       0      0      0       0       0      0      0
loop4      0      0       0       0      0      0       0       0      0      0
loop5      0      0       0       0      0      0       0       0      0      0
loop6      0      0       0       0      0      0       0       0      0      0
loop7      0      0       0       0      0      0       0       0      0      0


disk- ------------reads------------ ------------writes----------- -----IO------
       total merged sectors      ms  total merged sectors      ms    cur    sec
nvme0n1  87787    629 15882401   47181 756219  25189 60103306 1911481      0    246
loop0      0      0       0       0      0      0       0       0      0      0
loop1      0      0       0       0      0      0       0       0      0      0
loop2      0      0       0       0      0      0       0       0      0      0
loop3      0      0       0       0      0      0       0       0      0      0
loop4      0      0       0       0      0      0       0       0      0      0
loop5      0      0       0       0      0      0       0       0      0      0
loop6      0      0       0       0      0      0       0       0      0      0
loop7      0      0       0       0      0      0       0       0      0      0
```

```
$ cargo run -q vmstat -D && echo '\n' && vmstat -D
            9 disks
            8 partitions
        87789 total reads
          629 merged reads
     15884129 read sectors
        47191 milli reading
       757487 writes
        25206 merged writes
     60175450 written sectors
      1921462 milli writing
            0 in progress IO
          247 milli spent IO
         1997 milli weighted IO


            9 disks
            8 partitions
        87789 total reads
          629 merged reads
     15884129 read sectors
        47191 milli reading
       757487 writes
        25206 merged writes
     60175450 written sectors
      1921462 milli writing
            0 inprogress IO
          247 milli spent IO
         1997 milli weighted IO
```

```
$ cargo run -q vmstat -p nvme0n1 && echo '\n' && vmstat -p nvme0n1 
nvme0n1         reads      read sectors      writes  requested writes
                87789          15884129      759103          60263578


nvme0n1         reads      read sectors      writes  requested writes
                87789          15884129      759103          60263578
$ cargo run -q vmstat -p nvme0n1p5 && echo '\n' && vmstat -p nvme0n1p5
nvme0n1p5       reads      read sectors      writes  requested writes
                31133            444776           0                 0


nvme0n1p5       reads      read sectors      writes  requested writes
                31133            444776           0                 0
```