### PR TITLE
ci: enable separate test for `skill`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,8 @@ jobs:
       - name: build and test all programs separately
         shell: bash
         run: |
-          ## TODO: add hugetop and skill
-          programs="free pgrep pidof pidwait pkill pmap ps pwdx slabtop snice sysctl tload top vmstat w watch"
+          ## TODO: add hugetop
+          programs="free pgrep pidof pidwait pkill pmap ps pwdx skill slabtop snice sysctl tload top vmstat w watch"
           for program in $programs; do
             echo "Building and testing $program"
             cargo test -p "uu_$program" || exit 1

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Ongoing:
 * `pmap`: Displays the memory map of a process.
 * `ps`: Displays information about active processes.
 * `pwdx`: Shows the current working directory of a process.
+* `skill`: Sends a signal to processes based on criteria like user, terminal, etc.
 * `slabtop`: Displays detailed kernel slab cache information in real time.
 * `snice`: Changes the scheduling priority of a running process.
 * `sysctl`: Read or write kernel parameters at run-time.
@@ -31,7 +32,6 @@ Ongoing:
 
 TODO:
 * `hugetop`: Report hugepage usage of processes and the system as a whole.
-* `skill`: Sends a signal to processes based on criteria like user, terminal, etc.
 
 Elsewhere:
 


### PR DESCRIPTION
This PR enables `skill` in the `test_separately` job. And it moves `skill` to the "Ongoing" list in the readme.