### PR TITLE
Bump `ctor` from `0.4.1` to `0.5.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,7 +323,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec09e802f5081de6157da9a75701d6c713d8dc3ba52571fd4bd25f412644e8a6"
 dependencies = [
  "ctor-proc-macro",
- "dtor",
+ "dtor 0.0.6",
+]
+
+[[package]]
+name = "ctor"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67773048316103656a637612c4a62477603b777d91d9c62ff2290f9cde178fdb"
+dependencies = [
+ "ctor-proc-macro",
+ "dtor 0.1.0",
 ]
 
 [[package]]
@@ -483,7 +493,16 @@ version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97cbdf2ad6846025e8e25df05171abfb30e3ababa12ee0a0e44b9bbe570633a8"
 dependencies = [
- "dtor-proc-macro",
+ "dtor-proc-macro 0.0.5",
+]
+
+[[package]]
+name = "dtor"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e58a0764cddb55ab28955347b45be00ade43d4d6f3ba4bf3dc354e4ec9432934"
+dependencies = [
+ "dtor-proc-macro 0.0.6",
 ]
 
 [[package]]
@@ -491,6 +510,12 @@ name = "dtor-proc-macro"
 version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7454e41ff9012c00d53cf7f475c5e3afa3b91b7c90568495495e8d9bf47a1055"
+
+[[package]]
+name = "dtor-proc-macro"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
 
 [[package]]
 name = "either"
@@ -1049,7 +1074,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "clap_mangen",
- "ctor",
+ "ctor 0.5.0",
  "libc",
  "phf",
  "phf_codegen",
@@ -1890,7 +1915,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12453ee52c9cffa6bf2c74f9f35ed0c824b846cb0b4bdee829d8150332e7204c"
 dependencies = [
- "ctor",
+ "ctor 0.4.3",
  "glob",
  "libc",
  "nix",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ clap = { version = "4.5.4", features = ["wrap_help", "cargo", "env"] }
 clap_complete = "4.5.2"
 clap_mangen = "0.2.20"
 crossterm = "0.29.0"
-ctor = "0.4.1"
+ctor = "0.5.0"
 dirs = "6.0.0"
 libc = "0.2.154"
 nix = { version = "0.30", default-features = false, features = ["process"] }


### PR DESCRIPTION
This PR manually bumps `ctor` from `0.4.1` to `0.5.0` because renovate fails with a "Artifact update problem" in https://github.com/uutils/procps/pull/485