### PR TITLE
Bump `phf` from `0.12.1` to `0.13.1`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,7 +167,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
 dependencies = [
  "chrono",
- "phf",
+ "phf 0.12.1",
 ]
 
 [[package]]
@@ -980,6 +980,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
 dependencies = [
  "phf_shared 0.12.1",
+]
+
+[[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_shared 0.13.1",
  "serde",
 ]
 
@@ -1085,7 +1094,7 @@ dependencies = [
  "clap_mangen",
  "ctor 0.5.0",
  "libc",
- "phf",
+ "phf 0.13.1",
  "phf_codegen",
  "pretty_assertions",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ ctor = "0.5.0"
 dirs = "6.0.0"
 libc = "0.2.154"
 nix = { version = "0.30", default-features = false, features = ["process"] }
-phf = "0.12.1"
+phf = "0.13.1"
 phf_codegen = "0.13.0"
 prettytable-rs = "0.10.0"
 rand = { version = "0.9.0", features = ["small_rng"] }


### PR DESCRIPTION
This PR manually bumps `phf` from `0.12.1` to `0.13.1` because renovate fails with an "Artifact update problem" error in https://github.com/uutils/procps/pull/503