### PR TITLE
Bump `uutest` & remove unused imports in tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,6 +95,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
+name = "bstr"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -318,22 +329,12 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec09e802f5081de6157da9a75701d6c713d8dc3ba52571fd4bd25f412644e8a6"
-dependencies = [
- "ctor-proc-macro",
- "dtor 0.0.6",
-]
-
-[[package]]
-name = "ctor"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67773048316103656a637612c4a62477603b777d91d9c62ff2290f9cde178fdb"
 dependencies = [
  "ctor-proc-macro",
- "dtor 0.1.0",
+ "dtor",
 ]
 
 [[package]]
@@ -441,7 +442,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.0",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -479,6 +480,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "dns-lookup"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "853d5bcf0b73bd5e6d945b976288621825c7166e9f06c5a035ae1aaf42d1b64f"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "socket2",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "document-features"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -489,27 +502,12 @@ dependencies = [
 
 [[package]]
 name = "dtor"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97cbdf2ad6846025e8e25df05171abfb30e3ababa12ee0a0e44b9bbe570633a8"
-dependencies = [
- "dtor-proc-macro 0.0.5",
-]
-
-[[package]]
-name = "dtor"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e58a0764cddb55ab28955347b45be00ade43d4d6f3ba4bf3dc354e4ec9432934"
 dependencies = [
- "dtor-proc-macro 0.0.6",
+ "dtor-proc-macro",
 ]
-
-[[package]]
-name = "dtor-proc-macro"
-version = "0.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7454e41ff9012c00d53cf7f475c5e3afa3b91b7c90568495495e8d9bf47a1055"
 
 [[package]]
 name = "dtor-proc-macro"
@@ -759,6 +757,47 @@ name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "jiff"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
+dependencies = [
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1283705eb0a21404d2bfd6eef2a7593d240bc42a0bdb39db0ad6fa2ec026524"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
 
 [[package]]
 name = "js-sys"
@@ -1037,6 +1076,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "portable-atomic"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1092,7 +1146,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "clap_mangen",
- "ctor 0.5.0",
+ "ctor",
  "libc",
  "phf 0.13.1",
  "phf_codegen",
@@ -1120,7 +1174,7 @@ dependencies = [
  "uu_vmstat",
  "uu_w",
  "uu_watch",
- "uucore",
+ "uucore 0.1.0",
  "uutests",
  "xattr",
 ]
@@ -1707,7 +1761,7 @@ dependencies = [
  "bytesize",
  "clap",
  "sysinfo",
- "uucore",
+ "uucore 0.1.0",
  "windows 0.62.0",
 ]
 
@@ -1717,7 +1771,7 @@ version = "0.0.1"
 dependencies = [
  "clap",
  "regex",
- "uucore",
+ "uucore 0.1.0",
  "walkdir",
 ]
 
@@ -1727,7 +1781,7 @@ version = "0.0.1"
 dependencies = [
  "clap",
  "uu_pgrep",
- "uucore",
+ "uucore 0.1.0",
 ]
 
 [[package]]
@@ -1738,7 +1792,7 @@ dependencies = [
  "nix",
  "regex",
  "uu_pgrep",
- "uucore",
+ "uucore 0.1.0",
 ]
 
 [[package]]
@@ -1749,7 +1803,7 @@ dependencies = [
  "nix",
  "regex",
  "uu_pgrep",
- "uucore",
+ "uucore 0.1.0",
  "walkdir",
 ]
 
@@ -1759,7 +1813,7 @@ version = "0.0.1"
 dependencies = [
  "clap",
  "dirs",
- "uucore",
+ "uucore 0.1.0",
 ]
 
 [[package]]
@@ -1772,7 +1826,7 @@ dependencies = [
  "nix",
  "prettytable-rs",
  "uu_pgrep",
- "uucore",
+ "uucore 0.1.0",
 ]
 
 [[package]]
@@ -1781,7 +1835,7 @@ version = "0.0.1"
 dependencies = [
  "clap",
  "sysinfo",
- "uucore",
+ "uucore 0.1.0",
 ]
 
 [[package]]
@@ -1791,7 +1845,7 @@ dependencies = [
  "clap",
  "nix",
  "uu_snice",
- "uucore",
+ "uucore 0.1.0",
 ]
 
 [[package]]
@@ -1799,7 +1853,7 @@ name = "uu_slabtop"
 version = "0.0.1"
 dependencies = [
  "clap",
- "uucore",
+ "uucore 0.1.0",
 ]
 
 [[package]]
@@ -1813,7 +1867,7 @@ dependencies = [
  "sysinfo",
  "thiserror 2.0.16",
  "uu_pgrep",
- "uucore",
+ "uucore 0.1.0",
 ]
 
 [[package]]
@@ -1822,7 +1876,7 @@ version = "0.0.1"
 dependencies = [
  "clap",
  "sysinfo",
- "uucore",
+ "uucore 0.1.0",
  "walkdir",
 ]
 
@@ -1833,7 +1887,7 @@ dependencies = [
  "clap",
  "crossterm 0.29.0",
  "ratatui",
- "uucore",
+ "uucore 0.1.0",
 ]
 
 [[package]]
@@ -1851,7 +1905,7 @@ dependencies = [
  "sysinfo",
  "uu_vmstat",
  "uu_w",
- "uucore",
+ "uucore 0.1.0",
  "windows-sys 0.61.0",
 ]
 
@@ -1864,7 +1918,7 @@ dependencies = [
  "clap",
  "terminal_size",
  "uu_slabtop",
- "uucore",
+ "uucore 0.1.0",
 ]
 
 [[package]]
@@ -1874,7 +1928,7 @@ dependencies = [
  "chrono",
  "clap",
  "libc",
- "uucore",
+ "uucore 0.1.0",
 ]
 
 [[package]]
@@ -1882,7 +1936,7 @@ name = "uu_watch"
 version = "0.0.1"
 dependencies = [
  "clap",
- "uucore",
+ "uucore 0.1.0",
 ]
 
 [[package]]
@@ -1894,7 +1948,7 @@ dependencies = [
  "chrono",
  "chrono-tz",
  "clap",
- "dns-lookup",
+ "dns-lookup 2.1.1",
  "fluent",
  "fluent-bundle",
  "iana-time-zone",
@@ -1906,9 +1960,33 @@ dependencies = [
  "time",
  "unic-langid",
  "utmp-classic",
- "uucore_procs",
+ "uucore_procs 0.1.0",
  "wild",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "uucore"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52e9182faf0952030e96fdfa76e733ef10981cad31a89bc790d3410f85b7f0c"
+dependencies = [
+ "bstr",
+ "clap",
+ "dns-lookup 3.0.0",
+ "fluent",
+ "fluent-bundle",
+ "fluent-syntax",
+ "jiff",
+ "libc",
+ "nix",
+ "number_prefix",
+ "os_display",
+ "thiserror 2.0.16",
+ "time",
+ "unic-langid",
+ "uucore_procs 0.2.0",
+ "wild",
 ]
 
 [[package]]
@@ -1919,7 +1997,18 @@ checksum = "c933945fdac5b7779eae1fc746146e61f5b0298deb6ede002ce0b6e93e1b3bfc"
 dependencies = [
  "proc-macro2",
  "quote",
- "uuhelp_parser",
+ "uuhelp_parser 0.1.0",
+]
+
+[[package]]
+name = "uucore_procs"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8624767e57fc437268b166c09c8f6d1461bf7dc8ffe86b4f0bd3b36aca1253bc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "uuhelp_parser 0.2.0",
 ]
 
 [[package]]
@@ -1929,13 +2018,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "beda381dd5c7927f8682f50b055b0903bb694ba5a4b27fad1b4934bc4fbf7b8d"
 
 [[package]]
-name = "uutests"
-version = "0.1.0"
+name = "uuhelp_parser"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12453ee52c9cffa6bf2c74f9f35ed0c824b846cb0b4bdee829d8150332e7204c"
+checksum = "e54f43a40bcb9c63b41f48698c03ae07604358e707cca7372f1ffa21a0b76a81"
+
+[[package]]
+name = "uutests"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b5908554cef4685dc17d0a5d547f85e8f915b2982ed6cb1b753f7ae47bf915"
 dependencies = [
- "ctor 0.4.3",
- "glob",
+ "ctor",
  "libc",
  "nix",
  "pretty_assertions",
@@ -1943,8 +2037,7 @@ dependencies = [
  "regex",
  "rlimit",
  "tempfile",
- "time",
- "uucore",
+ "uucore 0.2.0",
  "xattr",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ terminal_size = "0.4.2"
 textwrap = { version = "0.16.1", features = ["terminal_size"] }
 thiserror = "2.0.4"
 uucore = "0.1.0"
-uutests = "0.1.0"
+uutests = "0.2.0"
 walkdir = "2.5.0"
 windows = { version = "0.62.0" }
 windows-sys = { version = "0.61.0", default-features = false }

--- a/tests/by-util/test_free.rs
+++ b/tests/by-util/test_free.rs
@@ -7,8 +7,6 @@ use pretty_assertions::assert_eq;
 use regex::Regex;
 
 use uutests::new_ucmd;
-use uutests::util::TestScenario;
-use uutests::util_name;
 
 // TODO: make tests combineable (e.g. test --total --human)
 

--- a/tests/by-util/test_pgrep.rs
+++ b/tests/by-util/test_pgrep.rs
@@ -12,8 +12,6 @@ use std::{
 #[cfg(target_os = "linux")]
 use regex::Regex;
 use uutests::new_ucmd;
-use uutests::util::TestScenario;
-use uutests::util_name;
 
 #[cfg(target_os = "linux")]
 const SINGLE_PID: &str = "^[1-9][0-9]*";

--- a/tests/by-util/test_pidof.rs
+++ b/tests/by-util/test_pidof.rs
@@ -4,8 +4,6 @@
 // file that was distributed with this source code.
 
 use uutests::new_ucmd;
-use uutests::util::TestScenario;
-use uutests::util_name;
 
 #[test]
 fn test_no_args() {

--- a/tests/by-util/test_pidwait.rs
+++ b/tests/by-util/test_pidwait.rs
@@ -4,8 +4,6 @@
 // file that was distributed with this source code.
 
 use uutests::new_ucmd;
-use uutests::util::TestScenario;
-use uutests::util_name;
 
 #[test]
 fn test_invalid_arg() {

--- a/tests/by-util/test_pkill.rs
+++ b/tests/by-util/test_pkill.rs
@@ -5,10 +5,6 @@
 
 #[cfg(unix)]
 use uutests::new_ucmd;
-#[cfg(unix)]
-use uutests::util::TestScenario;
-#[cfg(unix)]
-use uutests::util_name;
 
 #[cfg(unix)]
 #[test]

--- a/tests/by-util/test_pmap.rs
+++ b/tests/by-util/test_pmap.rs
@@ -8,8 +8,8 @@ use regex::Regex;
 #[cfg(target_os = "linux")]
 use std::process;
 use uutests::new_ucmd;
-use uutests::util::TestScenario;
-use uutests::util_name;
+#[cfg(target_os = "linux")]
+use uutests::{util::TestScenario, util_name};
 
 const NON_EXISTING_PID: &str = "999999";
 #[cfg(target_os = "linux")]

--- a/tests/by-util/test_ps.rs
+++ b/tests/by-util/test_ps.rs
@@ -4,8 +4,6 @@
 // file that was distributed with this source code.
 
 use uutests::new_ucmd;
-use uutests::util::TestScenario;
-use uutests::util_name;
 
 #[test]
 #[cfg(target_os = "linux")]

--- a/tests/by-util/test_pwdx.rs
+++ b/tests/by-util/test_pwdx.rs
@@ -8,8 +8,6 @@ use std::process;
 use regex::Regex;
 
 use uutests::new_ucmd;
-use uutests::util::TestScenario;
-use uutests::util_name;
 
 #[test]
 fn test_no_args() {

--- a/tests/by-util/test_skill.rs
+++ b/tests/by-util/test_skill.rs
@@ -4,8 +4,6 @@
 // file that was distributed with this source code.
 
 use uutests::new_ucmd;
-use uutests::util::TestScenario;
-use uutests::util_name;
 
 #[test]
 fn test_no_args() {

--- a/tests/by-util/test_slabtop.rs
+++ b/tests/by-util/test_slabtop.rs
@@ -7,8 +7,8 @@
 use uutests::util::run_ucmd_as_root;
 
 use uutests::new_ucmd;
-use uutests::util::TestScenario;
-use uutests::util_name;
+#[cfg(target_os = "linux")]
+use uutests::{util::TestScenario, util_name};
 
 #[test]
 fn test_invalid_arg() {

--- a/tests/by-util/test_snice.rs
+++ b/tests/by-util/test_snice.rs
@@ -4,8 +4,6 @@
 // file that was distributed with this source code.
 
 use uutests::new_ucmd;
-use uutests::util::TestScenario;
-use uutests::util_name;
 
 #[test]
 fn test_no_args() {

--- a/tests/by-util/test_sysctl.rs
+++ b/tests/by-util/test_sysctl.rs
@@ -4,8 +4,6 @@
 // file that was distributed with this source code.
 
 use uutests::new_ucmd;
-use uutests::util::TestScenario;
-use uutests::util_name;
 
 #[test]
 fn test_invalid_arg() {
@@ -16,8 +14,6 @@ fn test_invalid_arg() {
 mod linux {
 
     use uutests::new_ucmd;
-    use uutests::util::TestScenario;
-    use uutests::util_name;
 
     #[test]
     fn test_get_simple() {
@@ -75,8 +71,6 @@ mod linux {
 mod non_linux {
 
     use uutests::new_ucmd;
-    use uutests::util::TestScenario;
-    use uutests::util_name;
 
     #[test]
     fn test_fails_on_unsupported_platforms() {

--- a/tests/by-util/test_tload.rs
+++ b/tests/by-util/test_tload.rs
@@ -4,8 +4,6 @@
 // file that was distributed with this source code.
 
 use uutests::new_ucmd;
-use uutests::util::TestScenario;
-use uutests::util_name;
 
 #[test]
 fn test_invalid_arg() {

--- a/tests/by-util/test_top.rs
+++ b/tests/by-util/test_top.rs
@@ -4,8 +4,6 @@
 // file that was distributed with this source code.
 
 use uutests::new_ucmd;
-use uutests::util::TestScenario;
-use uutests::util_name;
 
 #[test]
 fn test_invalid_arg() {

--- a/tests/by-util/test_vmstat.rs
+++ b/tests/by-util/test_vmstat.rs
@@ -6,8 +6,6 @@
 #[cfg(target_os = "linux")]
 use std::time::Duration;
 use uutests::new_ucmd;
-use uutests::util::TestScenario;
-use uutests::util_name;
 
 #[test]
 fn test_simple() {

--- a/tests/by-util/test_w.rs
+++ b/tests/by-util/test_w.rs
@@ -4,8 +4,6 @@
 // file that was distributed with this source code.
 
 use uutests::new_ucmd;
-use uutests::util::TestScenario;
-use uutests::util_name;
 
 #[test]
 fn test_invalid_arg() {

--- a/tests/by-util/test_watch.rs
+++ b/tests/by-util/test_watch.rs
@@ -4,8 +4,6 @@
 // file that was distributed with this source code.
 
 use uutests::new_ucmd;
-use uutests::util::TestScenario;
-use uutests::util_name;
 
 // runddl32.exe has no console window, no side effects,
 // and no arguments are required.


### PR DESCRIPTION
This PR bumps `uutest` from `0.1.0` to `0.2.0` and removes imports in tests that are no longer needed. It also makes some imports linux-only.