### PR TITLE
vmstat: use `is_multiple_of` instead of manual impl

### DIFF
--- a/src/uu/vmstat/src/vmstat.rs
+++ b/src/uu/vmstat/src/vmstat.rs
@@ -139,7 +139,7 @@ fn print_slabs(one_header: bool, term_height: u16) -> UResult<()> {
 
 #[cfg(target_os = "linux")]
 fn needs_header(one_header: bool, term_height: u16, line_count: u64) -> bool {
-    !one_header && term_height > 0 && ((line_count + 3) % term_height as u64 == 0)
+    !one_header && term_height > 0 && (line_count + 3).is_multiple_of(term_height as u64)
 }
 
 #[cfg(target_os = "linux")]


### PR DESCRIPTION
This PR fixes a warning from the [manual_is_multiple_of](https://rust-lang.github.io/rust-clippy/master/index.html#manual_is_multiple_of) lint, a warning introduced with Rust `1.90.0`.