### PR TITLE
pgrep: optimize get `Namespace` via `statx` syscall

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,7 +289,7 @@ dependencies = [
  "document-features",
  "mio",
  "parking_lot",
- "rustix 1.0.5",
+ "rustix 1.1.2",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -772,7 +772,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -841,9 +841,9 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.4"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "litrs"
@@ -1142,7 +1142,7 @@ dependencies = [
  "chrono",
  "flate2",
  "procfs-core",
- "rustix 1.0.5",
+ "rustix 1.1.2",
 ]
 
 [[package]]
@@ -1359,15 +1359,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.5"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys 0.9.4",
- "windows-sys 0.59.0",
+ "linux-raw-sys 0.11.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1570,7 +1570,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.2",
  "once_cell",
- "rustix 1.0.5",
+ "rustix 1.1.2",
  "windows-sys 0.61.2",
 ]
 
@@ -1591,7 +1591,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b8cb979cb11c32ce1603f8137b22262a9d131aaa5c37b5678025f22b8becd0"
 dependencies = [
- "rustix 1.0.5",
+ "rustix 1.1.2",
  "windows-sys 0.60.2",
 ]
 
@@ -1805,6 +1805,7 @@ version = "0.0.1"
 dependencies = [
  "clap",
  "regex",
+ "rustix 1.1.2",
  "uucore 0.2.2",
  "walkdir",
 ]
@@ -2564,7 +2565,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
- "rustix 1.0.5",
+ "rustix 1.1.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ prettytable-rs = "0.10.0"
 rand = { version = "0.9.0", features = ["small_rng"] }
 ratatui = "0.29.0"
 regex = "1.10.4"
+rustix = { version = "1.1.2", features = ["fs"] }
 sysinfo = "0.37.0"
 tempfile = "3.10.1"
 terminal_size = "0.4.2"

--- a/src/uu/pgrep/Cargo.toml
+++ b/src/uu/pgrep/Cargo.toml
@@ -14,10 +14,11 @@ version.workspace = true
 workspace = true
 
 [dependencies]
-uucore = { workspace = true, features = ["entries", "signals", "process"] }
 clap = { workspace = true }
-walkdir = { workspace = true }
 regex = { workspace = true }
+rustix = { workspace = true }
+uucore = { workspace = true, features = ["entries", "signals", "process"] }
+walkdir = { workspace = true }
 
 [lib]
 path = "src/pgrep.rs"


### PR DESCRIPTION
Notice: this PR required the `statx` syscall, which was added in Linux 4.11

And also, make the field of `Namespace` from `string` to `u64`

---

This pr is a part of #162 