### PR TITLE
process: Fix tty resolving

### DIFF
--- a/src/uu/ps/src/picker.rs
+++ b/src/uu/ps/src/picker.rs
@@ -135,10 +135,11 @@ fn sid(proc_info: RefCell<ProcessInformation>) -> String {
 }
 
 fn tty(proc_info: RefCell<ProcessInformation>) -> String {
-    match proc_info.borrow().tty() {
-        Teletype::Tty(tty) => format!("tty{tty}"),
-        Teletype::TtyS(ttys) => format!("ttyS{ttys}"),
-        Teletype::Pts(pts) => format!("pts/{pts}"),
+    match proc_info.borrow_mut().tty() {
+        Teletype::Known(device_path) => device_path
+            .strip_prefix("/dev/")
+            .unwrap_or(&device_path)
+            .to_owned(),
         Teletype::Unknown => "?".to_owned(),
     }
 }

--- a/src/uu/snice/src/snice.rs
+++ b/src/uu/snice/src/snice.rs
@@ -129,7 +129,7 @@ pub fn ask_user(pid: u32) -> bool {
     let process = process_snapshot().process(Pid::from_u32(pid)).unwrap();
 
     let tty = ProcessInformation::try_new(PathBuf::from_str(&format!("/proc/{pid}")).unwrap())
-        .map(|v| v.tty().to_string())
+        .map(|mut v| v.tty().to_string())
         .unwrap_or(String::from("?"));
 
     let user = process
@@ -188,7 +188,8 @@ pub fn construct_verbose_result(
             let process = process_snapshot().process(Pid::from_u32(pid)).unwrap();
 
             let tty =
-                ProcessInformation::try_new(PathBuf::from_str(&format!("/proc/{pid}")).unwrap());
+                ProcessInformation::try_new(PathBuf::from_str(&format!("/proc/{pid}")).unwrap())
+                    .map(|mut v| v.tty().to_string());
 
             let user = process
                 .user_id()
@@ -214,7 +215,7 @@ pub fn construct_verbose_result(
                 row![pid]
             }
             Some((tty, user, cmd, action)) => {
-                row![tty.unwrap().tty(), user, pid, cmd, action]
+                row![tty.unwrap(), user, pid, cmd, action]
             }
         })
         .collect::<Table>();


### PR DESCRIPTION
Current tty resolution can give wrong result e.g. if the process has closed all fds of its controlling terminal. The proper way to do it seems to be based on field in /proc/<pid>/stat, which gives a device number of the tty. Converting that to a device path requires parsing /proc/tty/drivers (according to strace of upstream ps).

After this `ps`, `ps -x` and `ps -a` give same processes as upstream ps.