### PR TITLE
Bump `rlimit` from `0.10.1` to `0.11.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -951,9 +951,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.177"
+version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
 name = "libredox"
@@ -1434,7 +1434,7 @@ dependencies = [
  "pretty_assertions",
  "rand 0.9.2",
  "regex",
- "rlimit",
+ "rlimit 0.11.0",
  "sysinfo",
  "tempfile",
  "textwrap",
@@ -1669,6 +1669,15 @@ name = "rlimit"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7043b63bd0cd1aaa628e476b80e6d4023a3b50eb32789f2728908107bd0c793a"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "rlimit"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f35ee2729c56bb610f6dba436bf78135f728b7373bdffae2ec815b2d3eb98cc3"
 dependencies = [
  "libc",
 ]
@@ -2450,7 +2459,7 @@ dependencies = [
  "pretty_assertions",
  "rand 0.9.2",
  "regex",
- "rlimit",
+ "rlimit 0.10.2",
  "tempfile",
  "uucore",
  "xattr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,7 +130,7 @@ uutests = { workspace = true }
 xattr = { workspace = true }
 
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dev-dependencies]
-rlimit = "0.10.1"
+rlimit = "0.11.0"
 
 [build-dependencies]
 phf_codegen = { workspace = true }


### PR DESCRIPTION
This PR manually bumps `rlimit` from `0.10.1` to `0.11.0` because renovate fails with an "Artifact update problem" in https://github.com/uutils/procps/pull/610