### PR TITLE
w, top: fix nusers and loadavg

### DIFF
--- a/src/uu/top/src/header.rs
+++ b/src/uu/top/src/header.rs
@@ -8,8 +8,8 @@ use crate::platform::*;
 use crate::tui::stat::{CpuValueMode, TuiStat};
 use bytesize::ByteSize;
 use uu_vmstat::{CpuLoad, CpuLoadRaw};
-use uu_w::get_formatted_uptime_procps;
-use uucore::uptime::{get_formatted_loadavg, get_formatted_nusers, get_formatted_time};
+use uu_w::{get_formatted_loadavg, get_formatted_nusers, get_formatted_uptime_procps};
+use uucore::uptime::get_formatted_time;
 
 pub(crate) struct Header {
     pub uptime: Uptime,
@@ -113,7 +113,7 @@ pub(crate) fn format_memory(memory_b: u64, unit: u64) -> f64 {
 fn user() -> String {
     #[cfg(target_os = "linux")]
     if let Ok(nusers) = get_nusers_systemd() {
-        return uucore::uptime::format_nusers(nusers);
+        return uu_w::format_nusers(nusers);
     }
 
     get_formatted_nusers()


### PR DESCRIPTION
Because of the locale work on uucore, nusers and loadavg functions are broken.

```text
$ cargo run w -q
 13:44:10 up 24 min,  uptime-user-count,  uptime-lib-format-loadavg
USER     TTY       LOGIN@   IDLE   JCPU   PCPU  WHAT
bluemang           13:19    0.00s  0.00   0     
bluemang tty1      13:19    24:30  0.06   0.06  /usr/bin/startplasma-wayland
bluemang pts/0     13:20    24:10  2109.931.63  /usr/bin/kded5
bluemang pts/1     13:32    1.92s  0.37   0.21  /usr/bin/zsh
```

So I restored the formatting functions for procps.