### PR TITLE
pgrep: The pattern is too long (more than 15 characters) and should be able to match pid correctly.

### DIFF
--- a/src/uu/pgrep/src/process_matcher.rs
+++ b/src/uu/pgrep/src/process_matcher.rs
@@ -161,25 +161,19 @@ pub fn get_match_settings(matches: &ArgMatches) -> UResult<Settings> {
         ));
     }
 
-    // Pre-collect pids to check for possible match due to long pattern
-    let pids = collect_matched_pids(&settings)?;
-    let mut matches = false;
-    if !pids.is_empty() {
-        matches = true;
-    }
-
-    if !matches && !settings.full && pattern.len() > 15 {
-        let msg = format!("pattern that searches for process name longer than 15 characters will result in zero matches\n\
-                           Try `{} -f' option to match against the complete command line.", uucore::util_name());
-        return Err(USimpleError::new(1, msg));
-    }
-
     Ok(settings)
 }
 
 pub fn find_matching_pids(settings: &Settings) -> UResult<Vec<ProcessInformation>> {
     let mut pids = collect_matched_pids(settings)?;
+
     if pids.is_empty() {
+        if !settings.full && settings.regex.as_str().len() > 15 {
+            let msg = format!("pattern that searches for process name longer than 15 characters will result in zero matches\n\
+                            Try `{} -f' option to match against the complete command line.", uucore::util_name());
+            return Err(USimpleError::new(1, msg));
+        }
+
         uucore::error::set_exit_code(1);
         Ok(pids)
     } else {


### PR DESCRIPTION
The PIDs should be obtained in advance. If the PIDs exist, it means the pattern matches, and there should be no length error.  

Closes: #121