### PR TITLE
pgrep: remove libc in pgrep

### DIFF
--- a/src/uu/pgrep/Cargo.toml
+++ b/src/uu/pgrep/Cargo.toml
@@ -16,7 +16,7 @@ workspace = true
 [dependencies]
 clap = { workspace = true }
 regex = { workspace = true }
-rustix = { workspace = true }
+rustix = { workspace = true, features = ["fs", "process", "thread"] }
 uucore = { workspace = true, features = ["entries", "signals", "process"] }
 walkdir = { workspace = true }
 


### PR DESCRIPTION
Use rustix instead of libc and unsafe functions such as getpgrp, getsid, flock, gettid, getppid, getpgid, and getsid.

Closes: #595
