### PR TITLE
top: Swich some uses of libc to rustix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2479,6 +2479,7 @@ dependencies = [
  "nix 0.30.1",
  "pkg-config",
  "ratatui",
+ "rustix",
  "sysinfo",
  "uu_vmstat",
  "uu_w",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ prettytable-rs = "0.10.0"
 rand = { version = "0.10.0" }
 ratatui = "0.30.0"
 regex = "1.10.4"
-rustix = { version = "1.1.2", features = ["fs", "process"] }
+rustix = { version = "1.1.2", features = ["fs", "process", "param"] }
 sysinfo = "0.38.0"
 tempfile = "3.10.1"
 terminal_size = "0.4.2"

--- a/src/uu/top/Cargo.toml
+++ b/src/uu/top/Cargo.toml
@@ -22,6 +22,7 @@ ratatui = { workspace = true, features = ["crossterm"] }
 sysinfo = { workspace = true }
 chrono = { workspace = true }
 bytesize = { workspace = true }
+rustix = { workspace = true }
 
 uu_vmstat = { path = "../vmstat" }
 uu_w = { path = "../w" }

--- a/src/uu/top/src/action.rs
+++ b/src/uu/top/src/action.rs
@@ -5,15 +5,11 @@
 
 #[cfg(target_os = "linux")]
 pub(crate) fn renice(pid: u32, nice_value: i32) -> uucore::error::UResult<()> {
+    use rustix::process::{setpriority_process, Pid};
     use uucore::error::USimpleError;
-    use uucore::libc::{setpriority, PRIO_PROCESS};
 
-    let result = unsafe { setpriority(PRIO_PROCESS, pid, nice_value) };
-    if result == -1 {
-        Err(USimpleError::new(0, "Permission Denied"))
-    } else {
-        Ok(())
-    }
+    let pid = Pid::from_raw(pid as i32);
+    setpriority_process(pid, nice_value).map_err(|_| USimpleError::new(0, "Permission Denied"))
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
Use rustix instead libc to provide getpriority, setpriorty and page size calls.

Part of #599


There's some remaining uses of `uucore::libc` after this change:
* types for calls to libsystemd (`sd_booted`, `sd_get_sessions`) + windows `SystemProcessorPerformanceInformation`
* calls to `sched_getscheduler` and `sched_getparam` that aren't implemented in rustix