### PR TITLE
pkill: remove libc in pkill

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2380,8 +2380,8 @@ name = "uu_pkill"
 version = "0.0.1"
 dependencies = [
  "clap",
- "nix 0.30.1",
  "regex",
+ "rustix",
  "uu_pgrep",
  "uucore",
  "walkdir",

--- a/src/uu/pkill/Cargo.toml
+++ b/src/uu/pkill/Cargo.toml
@@ -18,7 +18,7 @@ uucore = { workspace = true, features = ["entries"] }
 clap = { workspace = true }
 walkdir = { workspace = true }
 regex = { workspace = true }
-nix = { workspace = true, features = ["signal"] }
+rustix = { workspace = true, features = ["process"] }
 
 uu_pgrep = { path = "../pgrep" }
 


### PR DESCRIPTION
Use Rustix to replace Nix function calls, such as kill_process.

Closes: #596