### PR TITLE
ps: improve the parameter output of the ps command

### DIFF
--- a/src/uu/ps/src/process_selection.rs
+++ b/src/uu/ps/src/process_selection.rs
@@ -71,7 +71,7 @@ pub struct ProcessSelectionSettings {
 impl ProcessSelectionSettings {
     pub fn from_matches(matches: &ArgMatches) -> Self {
         Self {
-            select_all: matches.get_flag("A"),
+            select_all: matches.get_flag("A") || matches.get_flag("e"),
             select_non_session_leaders_with_tty: matches.get_flag("a"),
             select_non_session_leaders: matches.get_flag("d"),
             dont_require_tty: matches.get_flag("x"),

--- a/src/uu/ps/src/ps.rs
+++ b/src/uu/ps/src/ps.rs
@@ -202,7 +202,10 @@ pub fn uu_app() -> Command {
             Arg::new("A")
                 .short('A')
                 .help("all processes")
-                .visible_short_alias('e')
+                .action(ArgAction::SetTrue),
+            Arg::new("e")
+                .short('e')
+                .help("Select all processes. Identical to -A")
                 .action(ArgAction::SetTrue),
             Arg::new("a")
                 .short('a')

--- a/tests/by-util/test_ps.rs
+++ b/tests/by-util/test_ps.rs
@@ -13,9 +13,24 @@ use uucore::process::geteuid;
 #[test]
 #[cfg(target_os = "linux")]
 fn test_select_all_processes() {
-    for arg in ["-A", "-e"] {
-        // TODO ensure the output format is correct
-        new_ucmd!().arg(arg).succeeds();
+    let expected_headers = ["PID", "TTY", "TIME", "CMD"];
+
+    let args_sets = vec![vec!["-A"], vec!["-e"], vec!["-A", "-e"]];
+    for args in args_sets {
+        let result = new_ucmd!().args(&args).succeeds();
+        let lines: Vec<&str> = result.stdout_str().lines().collect();
+
+        assert!(
+            lines.len() >= 2,
+            "expected at least a header and one process row"
+        );
+
+        let headers: Vec<&str> = lines[0].split_whitespace().collect();
+        assert_eq!(
+            headers, expected_headers,
+            "unexpected header for args: {:?}",
+            args
+        );
     }
 }
 


### PR DESCRIPTION
Improve the parameter output of the ps command so that`cargo run -q ps -A -e` does not report errors.

```shell
$ ps -A -e |head -n5 && cargo run -q ps -A -e |head -n5
    PID TTY          TIME CMD
      1 ?        00:00:57 systemd
      2 ?        00:00:00 kthreadd
      3 ?        00:00:00 pool_workqueue_release
      4 ?        00:00:00 kworker/R-rcu_gp
 PID     TTY    TIME      CMD 
 1       ?      00:00:57  systemd 
 2       ?      00:00:00  kthreadd 
 3       ?      00:00:00  pool_workqueue_release 
 4       ?      00:00:00  kworker/R-rcu_gp 
```

Fix #669 