### PR TITLE
`w`: Fix formatting of command line value

### DIFF
--- a/src/uu/w/src/w.rs
+++ b/src/uu/w/src/w.rs
@@ -142,7 +142,8 @@ fn format_time(time: String) -> Result<String, chrono::format::ParseError> {
 #[cfg(target_os = "linux")]
 fn fetch_cmdline(pid: i32) -> Result<String, std::io::Error> {
     let cmdline_path = Path::new("/proc").join(pid.to_string()).join("cmdline");
-    fs::read_to_string(cmdline_path)
+    // See `proc_pid_cmdline(5)` man page for the format of /proc/<pid>/cmdline
+    fs::read_to_string(cmdline_path).map(|s| s.trim_end_matches('\0').replace('\0', " "))
 }
 
 #[cfg(target_os = "linux")]
@@ -452,11 +453,8 @@ mod tests {
     fn test_fetch_cmdline() {
         // uucore's utmpx returns an i32, so we cast to that to mimic it.
         let pid = process::id() as i32;
-        let path = Path::new("/proc").join(pid.to_string()).join("cmdline");
-        assert_eq!(
-            fs::read_to_string(path).unwrap(),
-            fetch_cmdline(pid).unwrap()
-        );
+        let cmdline = std::env::args().collect::<Vec<String>>().join(" ");
+        assert_eq!(cmdline, fetch_cmdline(pid).unwrap());
     }
 
     #[test]


### PR DESCRIPTION
The command line value exposed by the kernel in `/proc/<pid>/cmdline` represents whitespace as NULL bytes.
Using `read_to_string()` on this directly will cause the output to join all parts of the original command into one long string.
This PR adds a very simple fix to avoid this.

### Before:
```bash
$ cargo run -q w
 22:16:22 up  2:00,  1 user,  load average: 0.32, 0.37, 0.38
USER     TTY       LOGIN@   IDLE   JCPU   PCPU  WHAT
alx      tty1      20:16    1:59m  0.00   0     /bin/sh/usr/bin/niri-session-l
```
### After:
```bash
$ cargo run -q w
 22:17:02 up  2:00,  1 user,  load average: 0.67, 0.46, 0.41
USER     TTY       LOGIN@   IDLE   JCPU   PCPU  WHAT
alx      tty1      20:16    2:00m  0.00   0     /bin/sh /usr/bin/niri-session -l 
```