### PR TITLE
clippy: fix warnings with Rust 1.95.0

### DIFF
--- a/src/uu/pgrep/src/process_matcher.rs
+++ b/src/uu/pgrep/src/process_matcher.rs
@@ -405,9 +405,9 @@ fn process_flag_o_n(
             .collect::<Vec<_>>();
 
         if settings.newest {
-            filtered.sort_by(|a, b| b.pid.cmp(&a.pid));
+            filtered.sort_by_key(|b| std::cmp::Reverse(b.pid));
         } else {
-            filtered.sort_by(|a, b| a.pid.cmp(&b.pid));
+            filtered.sort_by_key(|a| a.pid);
         }
 
         vec![filtered.first().cloned().unwrap().clone()]

--- a/src/uu/pmap/src/smaps_format_parser.rs
+++ b/src/uu/pmap/src/smaps_format_parser.rs
@@ -316,10 +316,8 @@ pub fn parse_smaps(contents: &str) -> Result<SmapTable, Error> {
                 let val = val.strip_suffix(" kB").unwrap_or(val);
                 let val = get_smap_item_value(val)?;
                 match key {
-                    pmap_field_name::SIZE => {
-                        if smap_entry.map_line.size_in_kb != val {
-                            return Err(Error::from(ErrorKind::InvalidData));
-                        }
+                    pmap_field_name::SIZE if smap_entry.map_line.size_in_kb != val => {
+                        return Err(Error::from(ErrorKind::InvalidData));
                     }
                     pmap_field_name::KERNEL_PAGE_SIZE => {
                         smap_entry.kernel_page_size_in_kb = val;

--- a/src/uu/ps/src/sorting.rs
+++ b/src/uu/ps/src/sorting.rs
@@ -13,5 +13,5 @@ pub(crate) fn sort(input: &mut [ProcessInformation], _matches: &ArgMatches) {
 
 /// Sort by pid. (Default)
 fn sort_by_pid(input: &mut [ProcessInformation]) {
-    input.sort_by(|a, b| a.pid.cmp(&b.pid));
+    input.sort_by_key(|a| a.pid);
 }


### PR DESCRIPTION
This PR fixes warnings from the [collapsible_match](https://rust-lang.github.io/rust-clippy/stable/index.html#collapsible_match) and [unnecessary_sort_by](https://rust-lang.github.io/rust-clippy/stable/index.html#unnecessary_sort_by) lints.