### PR TITLE
Bump `ctor` & adapt to change

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -396,9 +396,9 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.12.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8f521dd9c9e5f03986eb5c674b14b21e9ccf2eb9f98fecb681100214d5e9e4f"
+checksum = "f7335955a5f85f95f3188623240e081e7b2059a8ad1bae68944b7cfdd718fb10"
 dependencies = [
  "link-section",
  "linktime-proc-macro",
@@ -1059,9 +1059,9 @@ dependencies = [
 
 [[package]]
 name = "link-section"
-version = "0.12.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0567ec9fe5ffdf9241cd90a7629f250a5f903d6ff4573cf7903308662d6fce40"
+checksum = "ea2c24837c4fd5ab6a31d64133eae954f5199247523cf29586117e85245c0dd3"
 
 [[package]]
 name = "linktime-proc-macro"
@@ -1535,7 +1535,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "clap_mangen",
- "ctor 0.12.0",
+ "ctor 1.0.1",
  "jiff",
  "phf 0.13.1",
  "phf_codegen 0.13.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ clap = { version = "4.5.4", features = ["wrap_help", "cargo", "env"] }
 clap_complete = "4.5.2"
 clap_mangen = "0.3.0"
 crossterm = "0.29.0"
-ctor = "0.12.0"
+ctor = "1.0.0"
 dirs = "6.0.0"
 jiff = "0.2.15"
 nix = { version = "0.30", default-features = false, features = ["process"] }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -7,7 +7,7 @@ use std::env;
 pub const TESTS_BINARY: &str = env!("CARGO_BIN_EXE_procps");
 
 // Use the ctor attribute to run this function before any tests
-#[ctor::ctor]
+#[ctor::ctor(unsafe)]
 fn init() {
     unsafe {
         // Necessary for uutests to be able to find the binary


### PR DESCRIPTION
This PR bumps `ctor` from `0.12.0` to <del>`0.13.0`</del><del>`1.0.0`</del>`1.0.1` and adapts `tests/tests.rs` to a change in `ctor`.