### PR TITLE
use rustix process functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1628,6 +1628,7 @@ dependencies = [
  "rand 0.10.1",
  "regex",
  "rlimit",
+ "rustix",
  "sysinfo",
  "tempfile",
  "textwrap",
@@ -2458,6 +2459,7 @@ name = "uu_pidof"
 version = "0.0.1"
 dependencies = [
  "clap",
+ "rustix",
  "uu_pgrep",
  "uucore 0.7.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,6 +136,9 @@ xattr = { workspace = true }
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dev-dependencies]
 rlimit = "0.11.0"
 
+[target.'cfg(target_os = "linux")'.dependencies]
+rustix = { workspace = true }
+
 [build-dependencies]
 phf_codegen = { workspace = true }
 

--- a/src/uu/pgrep/src/process.rs
+++ b/src/uu/pgrep/src/process.rs
@@ -491,7 +491,7 @@ impl ProcessInformation {
 
     pub fn current_process_info() -> Result<ProcessInformation, io::Error> {
         #[cfg(target_os = "linux")]
-        let pid = uucore::process::getpid();
+        let pid = rustix::process::getpid().as_raw_pid();
         #[cfg(not(target_os = "linux"))]
         let pid = 0; // dummy
 
@@ -798,9 +798,9 @@ pub fn walk_threads() -> impl Iterator<Item = ProcessInformation> {
 mod tests {
     use super::*;
     #[cfg(target_os = "linux")]
-    use std::collections::HashSet;
+    use rustix::process::getpid;
     #[cfg(target_os = "linux")]
-    use uucore::process::getpid;
+    use std::collections::HashSet;
 
     #[test]
     #[cfg(target_os = "linux")]
@@ -870,7 +870,7 @@ unknown              /dev/tty        4 1-63 console"#;
     #[test]
     #[cfg(target_os = "linux")]
     fn test_walk_pid() {
-        let find = walk_process().find(|it| it.pid == getpid() as usize);
+        let find = walk_process().find(|it| it.pid == getpid().as_raw_pid() as usize);
 
         assert!(find.is_some());
     }
@@ -963,10 +963,16 @@ unknown              /dev/tty        4 1-63 console"#;
     #[cfg(target_os = "linux")]
     fn test_uid_gid() {
         let mut pid_entry = ProcessInformation::current_process_info().unwrap();
-        assert_eq!(pid_entry.uid().unwrap(), uucore::process::getuid());
-        assert_eq!(pid_entry.euid().unwrap(), uucore::process::geteuid());
-        assert_eq!(pid_entry.gid().unwrap(), uucore::process::getgid());
-        assert_eq!(pid_entry.egid().unwrap(), uucore::process::getegid());
+        assert_eq!(pid_entry.uid().unwrap(), rustix::process::getuid().as_raw());
+        assert_eq!(
+            pid_entry.euid().unwrap(),
+            rustix::process::geteuid().as_raw()
+        );
+        assert_eq!(pid_entry.gid().unwrap(), rustix::process::getgid().as_raw());
+        assert_eq!(
+            pid_entry.egid().unwrap(),
+            rustix::process::getegid().as_raw()
+        );
     }
 
     #[test]

--- a/src/uu/pidof/Cargo.toml
+++ b/src/uu/pidof/Cargo.toml
@@ -18,6 +18,9 @@ uucore = { workspace = true, features = ["process"] }
 clap = { workspace = true }
 uu_pgrep = { path = "../pgrep" }
 
+[target.'cfg(unix)'.dependencies]
+rustix = { workspace = true }
+
 [lib]
 path = "src/pidof.rs"
 

--- a/src/uu/pidof/src/pidof.rs
+++ b/src/uu/pidof/src/pidof.rs
@@ -6,10 +6,10 @@
 use std::path::PathBuf;
 
 use clap::{crate_version, Arg, ArgAction, ArgMatches, Command};
+#[cfg(unix)]
+use rustix::process::geteuid;
 use uu_pgrep::process::{walk_process, ProcessInformation};
 use uucore::error::UResult;
-#[cfg(unix)]
-use uucore::process::geteuid;
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
@@ -95,7 +95,7 @@ fn collect_matched_pids(matches: &ArgMatches) -> Vec<usize> {
 
     // Original pidof silently ignores the check-root option if the user is not root.
     #[cfg(unix)]
-    let check_root = matches.get_flag("check-root") && geteuid() == 0;
+    let check_root = matches.get_flag("check-root") && geteuid().as_raw() == 0;
     #[cfg(not(unix))]
     let check_root = false;
     let our_root = ProcessInformation::current_process_info()

--- a/tests/by-util/test_pgrep.rs
+++ b/tests/by-util/test_pgrep.rs
@@ -437,7 +437,7 @@ fn test_invalid_group_name() {
 fn test_current_user() {
     new_ucmd!()
         .arg("-U")
-        .arg(uucore::process::getuid().to_string())
+        .arg(rustix::process::getuid().as_raw().to_string())
         .succeeds();
 }
 

--- a/tests/by-util/test_ps.rs
+++ b/tests/by-util/test_ps.rs
@@ -8,7 +8,7 @@ use regex::Regex;
 use uutests::new_ucmd;
 
 #[cfg(target_os = "linux")]
-use uucore::process::geteuid;
+use rustix::process::geteuid;
 
 #[test]
 #[cfg(target_os = "linux")]
@@ -402,7 +402,7 @@ fn test_combined_selection_criteria() {
             "--pid",
             "1",
             "--user",
-            &geteuid().to_string(),
+            &geteuid().as_raw().to_string(),
             "--no-headers",
             "-o",
             "pid",


### PR DESCRIPTION
We want to remove the `rustix::process` functions, so use rustix directly in this crate.

cc: @cakebaker