### PR TITLE
Remove unused `uucore::process` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,7 +125,6 @@ tempfile = { workspace = true }
 uucore = { workspace = true, features = [
     "entries",
     "libc",
-    "process",
     "signals",
 ] }
 uutests = { workspace = true }

--- a/src/uu/pgrep/Cargo.toml
+++ b/src/uu/pgrep/Cargo.toml
@@ -17,7 +17,7 @@ workspace = true
 clap = { workspace = true }
 regex = { workspace = true }
 rustix = { workspace = true, features = ["fs", "process", "thread"] }
-uucore = { workspace = true, features = ["entries", "signals", "process"] }
+uucore = { workspace = true, features = ["entries", "signals"] }
 walkdir = { workspace = true }
 
 [lib]

--- a/src/uu/pidof/Cargo.toml
+++ b/src/uu/pidof/Cargo.toml
@@ -14,8 +14,8 @@ version.workspace = true
 workspace = true
 
 [dependencies]
-uucore = { workspace = true, features = ["process"] }
 clap = { workspace = true }
+uucore = { workspace = true }
 uu_pgrep = { path = "../pgrep" }
 
 [target.'cfg(unix)'.dependencies]


### PR DESCRIPTION
This PR is a follow-up to https://github.com/uutils/procps/pull/701 and removes the `uucore::process` feature from some `Cargo.toml` files.