### PR TITLE
clippy: fix warnings

### DIFF
--- a/src/uu/pgrep/src/process.rs
+++ b/src/uu/pgrep/src/process.rs
@@ -352,10 +352,8 @@ impl Namespace {
             ("user", &mut ns.user),
             ("uts", &mut ns.uts),
         ] {
-            match f(name, &ns_dir) {
-                Ok(st) => *slot = Some(st.stx_ino),
-                Err(e) => return Err(e.into()),
-            }
+            let st = f(name, &ns_dir)?;
+            *slot = Some(st.stx_ino);
         }
         Ok(ns)
     }

--- a/src/uu/top/src/header.rs
+++ b/src/uu/top/src/header.rs
@@ -68,7 +68,7 @@ impl Task {
         let mut stopped_process = 0;
         let mut zombie_process = 0;
 
-        for (_, process) in process.iter() {
+        for process in process.values() {
             match process.status() {
                 sysinfo::ProcessStatus::Run => running_process += 1,
                 sysinfo::ProcessStatus::Sleep => sleeping_process += 1,

--- a/src/uu/top/src/tui/mod.rs
+++ b/src/uu/top/src/tui/mod.rs
@@ -528,7 +528,7 @@ impl<'a> Tui<'a> {
             let constraints = [Constraint::Length(1), Constraint::Min(1)];
             let layout = Layout::new(Direction::Vertical, constraints).split(area);
             Line::from(Span::styled(
-                format!("{:<width$}", &info_bar.title, width = area.width as usize),
+                format!("{:<width$}", info_bar.title, width = area.width as usize),
                 Style::default().bg_secondary(self.stat.colorful),
             ))
             .render(layout[0], buf);


### PR DESCRIPTION
This PR fixes clippy warnings from the [question_mark](https://rust-lang.github.io/rust-clippy/master/index.html#question_mark), [for_kv_map](https://rust-lang.github.io/rust-clippy/master/index.html#for_kv_map), and [useless_borrows_in_formatting](https://rust-lang.github.io/rust-clippy/master/index.html#useless_borrows_in_formatting) lints that are shown with Rust `1.97`.