### PR TITLE
top,ps: remove `chrono`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2571,7 +2571,6 @@ dependencies = [
 name = "uu_ps"
 version = "0.0.1"
 dependencies = [
- "chrono",
  "clap",
  "prettytable-rs",
  "rustix",
@@ -2644,7 +2643,6 @@ name = "uu_top"
 version = "0.0.1"
 dependencies = [
  "bytesize",
- "chrono",
  "clap",
  "crossterm",
  "nix 0.30.1",

--- a/src/uu/ps/Cargo.toml
+++ b/src/uu/ps/Cargo.toml
@@ -14,10 +14,10 @@ version.workspace = true
 workspace = true
 
 [dependencies]
-uucore = { workspace = true, features = ["utmpx"] }
 clap = { workspace = true }
 prettytable-rs = { workspace = true }
 rustix = { workspace = true, features = ["fs", "process", "std", "termios"] }
+uucore = { workspace = true, features = ["utmpx"] }
 
 uu_pgrep = { path = "../pgrep" }
 

--- a/src/uu/ps/Cargo.toml
+++ b/src/uu/ps/Cargo.toml
@@ -16,7 +16,6 @@ workspace = true
 [dependencies]
 uucore = { workspace = true, features = ["utmpx"] }
 clap = { workspace = true }
-chrono = { workspace = true, default-features = false, features = ["clock"] }
 prettytable-rs = { workspace = true }
 rustix = { workspace = true, features = ["fs", "process", "std", "termios"] }
 

--- a/src/uu/top/Cargo.toml
+++ b/src/uu/top/Cargo.toml
@@ -14,14 +14,14 @@ version.workspace = true
 workspace = true
 
 [dependencies]
-uucore = { workspace = true, features = ["utmpx", "uptime", "signals", "libc"] }
+bytesize = { workspace = true }
 clap = { workspace = true }
 crossterm = { workspace = true }
 nix = { workspace = true }
 ratatui = { workspace = true, features = ["crossterm"] }
-sysinfo = { workspace = true }
-bytesize = { workspace = true }
 rustix = { workspace = true }
+sysinfo = { workspace = true }
+uucore = { workspace = true, features = ["utmpx", "uptime", "signals", "libc"] }
 
 uu_vmstat = { path = "../vmstat" }
 uu_w = { path = "../w" }

--- a/src/uu/top/Cargo.toml
+++ b/src/uu/top/Cargo.toml
@@ -20,7 +20,6 @@ crossterm = { workspace = true }
 nix = { workspace = true }
 ratatui = { workspace = true, features = ["crossterm"] }
 sysinfo = { workspace = true }
-chrono = { workspace = true }
 bytesize = { workspace = true }
 rustix = { workspace = true }
 


### PR DESCRIPTION
This PR removes the unused `chrono` dependency from `top` and `ps`. And it sorts the dependencies of those utils alphabetically.